### PR TITLE
ci: enforce conventional-commit PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,36 @@
+name: PR title
+
+# Enforces Conventional Commits on PR titles. Since main uses squash-merge
+# with the PR title as the commit subject, this is what actually keeps
+# main's history conventional — no commit-msg hook required.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            test
+            chore
+            ci
+            build
+            perf
+            style
+          requireScope: false
+          subjectPattern: ^[A-Za-z].+[^.]$
+          subjectPatternError: |
+            PR title subject must start with a letter and not end with a period.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-title.yml` using `amannn/action-semantic-pull-request@v5`
- Validates PR title against the conventional-commit types listed in `CLAUDE.md` (feat, fix, docs, refactor, test, chore, ci, build, perf, style)
- Since `main` uses squash-merge with the PR title as the commit subject, this is what keeps main's history conventional — no commit-msg hook needed

## Test plan
- [ ] This PR's own title passes the new check (it's conventional: `ci: enforce conventional-commit PR titles`)
- [ ] Try editing the title to something invalid and confirm the check fails
- [ ] After first successful run, add `PR title / lint` to the required status checks on `main` via `gh api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)