### PR TITLE
ci: pin claude review job name for branch protection

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,4 +1,4 @@
-name: Claude PR review
+name: PR checks
 
 # Auto-reviews pull requests with Claude Code using a Pro/Max OAuth token
 # (no Anthropic API key needed). Reviews count against subscription rate
@@ -24,6 +24,9 @@ concurrency:
 
 jobs:
   review:
+    # Pinned so branch protection can require the check by a stable name
+    # (`Claude PR review`) independent of workflow/file renames.
+    name: Claude PR review
     # Skip drafts by default — review them on demand via @claude mention
     if: >-
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false)


### PR DESCRIPTION
## Summary
- Pins the review job's \`name:\` to \`Claude PR review\` so branch protection can require it by a stable string independent of workflow/file renames
- Renames the workflow itself to \`PR checks\` so the PR UI doesn't render \`Claude PR review / Claude PR review\`

## Why
Branch protection was previously requiring a check literally named \`Claude PR review\`, but the actual reported check name was \`Claude PR review / review (pull_request)\` (workflow name + job id + event). The required check stayed pending forever while the real run succeeded. Pinning the job name decouples the required-check string from the workflow filename and trigger list.

## Test plan
- [ ] This PR itself exercises the rename — after merge (or once the first run completes), update the branch protection rule on \`main\` to require \`Claude PR review\` (no prefix, no suffix) and confirm the autocomplete shows exactly that string
- [ ] Confirm the review job still posts a review comment on this PR
- [ ] Confirm the PR UI shows \`PR checks / Claude PR review\` (not the doubled name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)