### PR TITLE
ci: make claude reviewer submit a formal gh pr review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -49,6 +49,11 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Surface the agent's full stdout/stderr in workflow logs so we
+          # can see what the review agent actually did (tool calls, final
+          # message) when the reviewer comment doesn't show up on a PR.
+          # Flip back to false once review behavior is stable.
+          show_full_output: true
           prompt: |
             You are reviewing a pull request in the SMILE-factory monorepo.
 
@@ -85,5 +90,19 @@ jobs:
               - Changes to PRDs under `prd/` — those are planning docs,
                 not production code
 
-            Be concise. If there are no substantive issues, post a short
-            approval comment rather than manufacturing feedback.
+            Be concise. Do not manufacture feedback to fill space.
+
+            **You MUST end every run by submitting exactly one PR review
+            via the `gh` CLI — never exit without submitting one.** This
+            makes you appear in the Reviewers box with an explicit state
+            rather than leaving an ambiguous plain comment. Use the PR
+            number from `${{ github.event.pull_request.number }}`.
+
+            - No substantive issues → `gh pr review <N> --approve --body "<short summary>"`
+            - Issues that must be fixed before merge → `gh pr review <N> --request-changes --body "<findings>"`
+            - Observations worth flagging but not blocking → `gh pr review <N> --comment --body "<findings>"`
+
+            If `gh pr review --approve` fails with a "cannot approve your
+            own pull request" error, fall back to `--comment` with the
+            same body — that happens when the PR author is the same
+            identity the workflow runs as.


### PR DESCRIPTION
## Summary
- Enables \`show_full_output: true\` on the claude-code-action so workflow logs surface the agent's tool calls and final message (currently hidden, which made the "no comment appeared" bug opaque)
- Rewrites the prompt's closing instructions to require every run end with \`gh pr review --approve|--request-changes|--comment\`, so the bot shows up in the Reviewers box with an explicit state instead of leaving ambiguous plain comments (or nothing at all)

## Why
On the previous PR the required check passed but no review comment ever showed up. Two gaps caused that: (1) the agent's output was hidden so we couldn't tell what it did, and (2) the old prompt said "post a short approval comment" softly — agents in this mode frequently exit silently when asked for a free-form comment. The reviews API is the correct mechanism for "this PR is approved / needs changes," and it also populates the Reviewers UI.

## Test plan
- [ ] This PR itself is the test: on first push, \`claude[bot]\` should appear under Reviewers with either an Approved or Commented state
- [ ] Workflow logs should show the agent's full transcript, including the \`gh pr review\` invocation
- [ ] If \`--approve\` fails because the workflow runs as the PR author's identity, the fallback \`--comment\` branch should kick in (documented in the prompt)
- [ ] Once review behavior is stable on a few PRs, flip \`show_full_output\` back to \`false\` in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)