### PR TITLE
ci: whitelist gh CLI so claude reviewer can submit reviews

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -54,12 +54,15 @@ jobs:
           # message) when the reviewer comment doesn't show up on a PR.
           # Flip back to false once review behavior is stable.
           show_full_output: true
-          # Whitelist `gh` so the agent can submit PR reviews. Claude
-          # Code's default bash allowlist blocks everything; without this,
-          # every `gh pr review --approve` call comes back as a
-          # permission_denial and the bot silently fails to post anything.
-          # Prefix-match syntax: Bash(<prefix>:*) covers all subcommands.
-          claude_args: --allowedTools "Bash(gh:*)"
+          # Whitelist only `gh pr review` so the agent can submit PR
+          # reviews. Claude Code's default bash allowlist blocks
+          # everything; without this, every `gh pr review --approve` call
+          # comes back as a permission_denial and the bot silently fails
+          # to post anything. Reading PR metadata/diff works via the
+          # default-allowed WebFetch tool against the GitHub REST API, so
+          # we don't need to whitelist `gh pr view`. Prefix-match syntax:
+          # Bash(<prefix>:*) matches any command beginning with <prefix>.
+          claude_args: --allowedTools "Bash(gh pr review:*)"
           prompt: |
             You are reviewing a pull request in the SMILE-factory monorepo.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -54,6 +54,12 @@ jobs:
           # message) when the reviewer comment doesn't show up on a PR.
           # Flip back to false once review behavior is stable.
           show_full_output: true
+          # Whitelist `gh` so the agent can submit PR reviews. Claude
+          # Code's default bash allowlist blocks everything; without this,
+          # every `gh pr review --approve` call comes back as a
+          # permission_denial and the bot silently fails to post anything.
+          # Prefix-match syntax: Bash(<prefix>:*) covers all subcommands.
+          claude_args: --allowedTools "Bash(gh:*)"
           prompt: |
             You are reviewing a pull request in the SMILE-factory monorepo.
 


### PR DESCRIPTION
## Summary
- Adds \`claude_args: --allowedTools \"Bash(gh:*)\"\` to the claude-code-action step so the review agent can actually call \`gh pr review\`

## Why
On PR #21 the workflow ran the full review, the agent drafted an approval body, and then tried to submit it via \`gh pr review 21 --approve\`. The workflow logs (now visible thanks to \`show_full_output: true\`) show every single bash call coming back as a \`permission_denial\` — Claude Code's default-deny sandbox blocks all bash invocations unless explicitly whitelisted. That's why the bot silently failed to post anything on #21 despite the check going green.

\`Bash(gh:*)\` is a prefix match covering every \`gh\` subcommand (read and write). It's the narrowest whitelist that unblocks both \`gh pr view\` (for reading PR metadata) and \`gh pr review\` (for submitting the review).

## Test plan
- [ ] Merge this (OIDC validation will fail on the PR itself since it edits the workflow file — same "workflow must match default branch" dance as #23 and #24)
- [ ] Push an empty commit to PR #21 again to retrigger a fresh run
- [ ] Confirm \`claude[bot]\` appears under Reviewers with an Approved / Commented state
- [ ] Confirm the workflow logs show a successful \`gh pr review\` invocation with no permission denials

🤖 Generated with [Claude Code](https://claude.com/claude-code)