### PR TITLE
ci: add actions/checkout to claude fix job

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -153,6 +153,14 @@ jobs:
       issues: write
       id-token: write
     steps:
+      # Tag mode's fetcher calls `git hash-object` / `git fetch` to
+      # compute SHAs and prepare the fix branch, so the runner needs an
+      # actual git working tree on disk. Without this step the action
+      # fails before any edits happen with "fatal: not a git repository".
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
Adds the missing \`actions/checkout@v4\` step to the \`fix\` job. Tag mode's fetcher needs a real git working tree on the runner to compute file SHAs (\`git hash-object\`) and prepare the fix branch (\`git fetch --depth=20 <pr-branch>\`). Without it the action crashes before any edits happen with \`fatal: not a git repository\`.

## Context
On the first real test of the fix flow (\`@claude\` comment on PR #26), the action blew up during tag-mode setup. I'd assumed tag mode handled checkout internally — it doesn't in v1. The review job already has \`actions/checkout\` for the same reason; this just applies the same treatment to \`fix\`.

## Test plan
- [ ] Merge this (OIDC dance again)
- [ ] Comment \`@claude\` on an open PR and confirm the fix job gets past the git setup phase
- [ ] Confirm a nested PR appears with the proposed fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)