### PR TITLE
ci: let tag mode use its native toolchain, skip bot-authored PR reviews

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,12 +33,18 @@ jobs:
     # Pinned so branch protection can require the check by a stable name
     # (`Claude PR review`) independent of workflow/file renames.
     name: Claude PR review
-    # Only fires on pull_request. `@claude` mentions on PRs go to the
-    # `fix` job below, not here — the two have different permissions
-    # and prompts.
+    # Only fires on pull_request events from human authors. `@claude`
+    # mentions on PRs go to the `fix` job below — the two have
+    # different permissions and prompts. Bot-authored PRs are skipped
+    # because (a) claude-code-action's `allowed_bots` default blocks
+    # them and they'd fail at startup anyway, and (b) when the fix job
+    # pushes a new commit to a PR branch, that triggers a new
+    # pull_request event — without this filter we'd burn subscription
+    # quota re-reviewing the same PR after every fix.
     if: >-
       github.event_name == 'pull_request'
       && github.event.pull_request.draft == false
+      && github.event.pull_request.user.login != 'claude[bot]'
     runs-on: ubuntu-latest
     concurrency:
       group: claude-review-${{ github.event.pull_request.number }}
@@ -129,9 +135,13 @@ jobs:
 
   fix:
     # On-demand fix flow: someone comments `@claude <request>` on a PR.
-    # The agent makes the requested changes and opens a *nested* PR
-    # against the source PR's head branch, so the fix is reviewable as
-    # a diff rather than silently rewriting the PR under the author.
+    # Tag mode is auto-detected from the issue_comment + @claude
+    # trigger. On an open PR, tag mode pushes new commits **directly**
+    # to the PR branch (see its own system prompt: "When triggered on
+    # an open PR: Always push directly to the existing PR branch").
+    # The fix shows up as a new commit on the same PR rather than as
+    # a separate nested PR — still reviewable in the PR's commit list,
+    # and this matches tag mode's native design.
     name: Claude PR fix
     if: >-
       github.event_name == 'issue_comment'
@@ -144,19 +154,20 @@ jobs:
       group: claude-fix-${{ github.event.issue.number }}
       cancel-in-progress: true
     permissions:
-      # `write` on contents is what lets the fix branch get pushed.
-      # The narrower `pull-requests: write` covers opening the nested
-      # PR. Tag mode's built-in gatekeeping only runs this for actors
-      # with repo write access, so a random PR commenter can't abuse it.
+      # `write` on contents is what lets the fix job push commits to
+      # the PR branch. Tag mode's built-in gatekeeping only runs this
+      # for actors with repo write access, so a random PR commenter
+      # can't abuse it.
       contents: write
       pull-requests: write
       issues: write
       id-token: write
     steps:
       # Tag mode's fetcher calls `git hash-object` / `git fetch` to
-      # compute SHAs and prepare the fix branch, so the runner needs an
-      # actual git working tree on disk. Without this step the action
-      # fails before any edits happen with "fatal: not a git repository".
+      # compute file SHAs and bootstrap the working tree, so the
+      # runner needs an actual git repo on disk. Without this step the
+      # action fails with "fatal: not a git repository" before any
+      # edits happen.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -164,19 +175,14 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          show_full_output: true
-          # Broader whitelist than the review job — the fix flow needs
-          # to run git (add/commit/push), gh (create the nested PR),
-          # and the built-in edit tools (Edit/Write/Read/Glob/Grep).
-          # Claude Code's --allowedTools replaces the default allowlist
-          # when set, so the built-ins have to be re-listed explicitly.
-          # WebFetch is included so the agent can read PR context from
-          # the GitHub REST API the same way the review job does.
-          claude_args: >-
-            --allowedTools "Edit,Write,Read,Glob,Grep,WebFetch,Bash(git:*),Bash(gh:*)"
-          # No explicit `prompt:` — in tag mode (auto-detected from the
-          # issue_comment + @claude mention), the action uses the
-          # comment body as the instruction and its built-in
-          # branch-and-PR machinery (see `branch_prefix` /
-          # `branch_name_template` in the action inputs) opens the
-          # nested PR against the source PR's head branch.
+          # No `claude_args --allowedTools` override here. Tag mode has
+          # its own carefully-designed allowlist that wires up the
+          # internal MCP file-ops tools and a specific `git-push.sh`
+          # wrapper script. Overriding --allowedTools replaces that
+          # list wholesale, which strips tag mode of the actual tools
+          # it uses to edit files and push — the agent then silently
+          # hallucinates "fixed and pushed" without running any edits.
+          # Let tag mode use its native defaults.
+          #
+          # No `prompt:` either — in tag mode the action uses the
+          # @claude comment body as the instruction.


### PR DESCRIPTION
## Summary
Two fixes from debugging the fix-job flow on the previous test:

### 1. Fix job: stop overriding \`--allowedTools\`
The agent on the last test run claimed "All three issues have been fixed and pushed to the branch" but the PR branch had zero new commits. Inspecting the run log, it had called exactly **one** tool across 14 turns: \`mcp__github_comment__update_claude_comment\`. No Edit, no Write, no Bash, no git.

Root cause: our \`claude_args --allowedTools "Edit,Write,..."\` **replaced** tag mode's carefully-designed internal allowlist. Tag mode's file-editing workflow goes through MCP file-ops tools and a specific \`git-push.sh\` wrapper script — not plain Edit/Write. Our override stripped those out, leaving the agent with no actual way to edit files. Instead of failing loudly it hallucinated the work as done, because no tool call was denied — there simply were no edit tools registered at all.

Hard lesson: **in tag mode, don't touch \`--allowedTools\`**. Let it use its native defaults.

### 2. Fix job: document that tag mode pushes directly to the PR branch
Tag mode's own system prompt, visible in the run log, says verbatim:
> When triggered on an open PR: Always push directly to the existing PR branch
> When triggered on an issue: Always create a new branch
> When triggered on a closed PR: Create a new branch

So v1 tag mode does **not** support nested PRs on open PRs regardless of what we configure. My earlier claim that it would open a nested PR against the source branch was wrong. Updated comments in the workflow reflect reality: fixes show up as new commits on the same PR. Still reviewable via the PR's commit list; you just can't merge the fix independently of the rest of the PR.

### 3. Review job: skip PRs authored by \`claude[bot]\`
When the fix job pushes commits to a PR, that fires a new \`pull_request\` synchronize event. If the PR was originally opened by \`claude[bot]\` (or becomes one when Claude opens a PR from an issue), the review job fires and immediately crashes at startup with:
> \`Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.\`

Filtering at the \`if:\` stage is cleaner than unblocking via \`allowed_bots\` — saves subscription quota and avoids the review→fix→review loop entirely.

## Test plan
- [ ] Merge this (OIDC dance again)
- [ ] Comment \`@claude fix <something>\` on an open, human-authored PR
- [ ] Confirm the fix job actually edits files and pushes a new commit to the PR branch
- [ ] Confirm the review job does NOT re-run on that new commit in a loop (this is the bot-filter's job, though note: if the new commit is pushed by claude[bot] but the PR author is human, the review will still run on synchronize — which is probably what you want; the filter only suppresses review when the PR *itself* is bot-authored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)