### PR TITLE
feat: stream sandbox events to the bot as an async iterator

### DIFF
--- a/apps/delulu_discord/src/delulu_discord/dispatcher.py
+++ b/apps/delulu_discord/src/delulu_discord/dispatcher.py
@@ -10,8 +10,8 @@ Modal; it only dispatches to a Modal App that was deployed from the sibling
 
 from __future__ import annotations
 
-import asyncio
-from typing import TYPE_CHECKING
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
 
 import modal
 import structlog
@@ -43,15 +43,19 @@ class SandboxDispatcher:
         resume: bool = False,
         attachments: list[tuple[str, bytes]] | None = None,
         message_id: int | None = None,
-    ) -> str:
-        """Dispatch a task to Modal and return the output.
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Dispatch a task to Modal and stream events as they arrive.
 
-        The Modal function is now a generator that yields event dicts —
-        this method collects the stream, finds the terminal
-        ``done`` / ``error`` event, and returns the final text as a
-        plain string so the rest of the bot keeps its current shape.
-        The async-generator driver that actually streams events to
-        Discord will replace this in a follow-up commit.
+        This is an **async generator**: callers iterate with
+        ``async for event in dispatcher.run_task(...)``. Each event is a
+        plain dict matching one of the shapes declared in
+        ``delulu_sandbox_modal.events`` (the bot cannot import the
+        TypedDicts across the app boundary, so they're typed as
+        ``dict[str, Any]`` here). The terminal event is ``done`` on a
+        clean run or ``error`` on a nonzero Claude Code exit.
+
+        Uses Modal's ``.remote_gen.aio`` so the stream is consumed
+        directly on the event loop — no ``run_in_executor`` dance.
         """
         logger.info(
             "dispatch.start",
@@ -60,63 +64,20 @@ class SandboxDispatcher:
             attachment_count=len(attachments) if attachments else 0,
         )
 
-        # .remote_gen() is a synchronous iterator — drain it in an executor
-        # so the bot's event loop stays responsive.
-        loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(
-            None,
-            lambda: self._collect_events(
-                session_id=session_id,
-                workspace_path=workspace_path,
-                prompt=prompt,
-                resume=resume,
-                attachments=attachments or [],
-                message_id=message_id,
-            ),
-        )
-
-        logger.info(
-            "dispatch.complete",
-            session_id=session_id,
-            output_length=len(result),
-        )
-        return result
-
-    def _collect_events(
-        self,
-        *,
-        session_id: str,
-        workspace_path: str,
-        prompt: str,
-        resume: bool,
-        attachments: list[tuple[str, bytes]],
-        message_id: int | None,
-    ) -> str:
-        """Drain the Modal generator and return the final text.
-
-        On an ``error`` event this appends the error message to whatever
-        partial text was produced, mirroring the old ``run_claude_code``
-        behaviour of tacking ``[stderr]`` onto nonzero-exit output.
-        """
-        final_text = ""
-        error_message: str | None = None
-        for event in self._fn.remote_gen(
+        event_count = 0
+        async for event in self._fn.remote_gen.aio(
             session_id=session_id,
             workspace_path=workspace_path,
             prompt=prompt,
             resume=resume,
-            attachments=attachments,
+            attachments=attachments or [],
             message_id=message_id,
         ):
-            etype = event.get("type") if isinstance(event, dict) else None
-            if etype == "done":
-                final_text = event.get("final_text") or final_text
-            elif etype == "error":
-                error_message = event.get("message") or "unknown error"
-        if error_message:
-            return (
-                f"{final_text}\n\n[error]\n{error_message}".strip()
-                if final_text
-                else f"[error] {error_message}"
-            )
-        return final_text
+            event_count += 1
+            yield event
+
+        logger.info(
+            "dispatch.complete",
+            session_id=session_id,
+            event_count=event_count,
+        )

--- a/apps/delulu_discord/src/delulu_discord/handlers.py
+++ b/apps/delulu_discord/src/delulu_discord/handlers.py
@@ -79,25 +79,46 @@ class MessageHandler:
         *,
         resume: bool,
     ) -> None:
-        """Run Claude Code in a Modal sandbox and post the result."""
-        # Show typing indicator while working
+        """Run Claude Code in a Modal sandbox and post the result.
+
+        ``dispatcher.run_task`` is now an async generator that yields
+        event dicts. This method drains the stream, picks the final
+        text out of the terminal ``done`` / ``error`` event, and still
+        posts a single message at the end — the live status message
+        and 1-edit/sec flush loop land in a follow-up commit.
+        """
+        final_text = ""
+        error_message: str | None = None
         async with thread.typing():
             try:
-                result = await self.dispatcher.run_task(
+                async for event in self.dispatcher.run_task(
                     session_id=session.session_id,
                     workspace_path=session.workspace_path,
                     prompt=prompt,
                     resume=resume,
                     attachments=attachments,
                     message_id=message_id,
-                )
+                ):
+                    etype = event.get("type") if isinstance(event, dict) else None
+                    if etype == "done":
+                        final_text = event.get("final_text") or final_text
+                    elif etype == "error":
+                        error_message = event.get("message") or "unknown error"
             except Exception:
                 logger.exception("task.failed", session_id=session.session_id)
                 await thread.send("Something went wrong running that task. Check the logs.")
                 return
 
-        # Post result, respecting Discord's character limit
-        await self._post_result(thread, result)
+        if error_message:
+            output = (
+                f"{final_text}\n\n[error]\n{error_message}".strip()
+                if final_text
+                else f"[error] {error_message}"
+            )
+        else:
+            output = final_text
+
+        await self._post_result(thread, output)
 
     async def _post_result(self, thread: discord.Thread, output: str) -> None:
         """Post output to thread, falling back to file upload if too long."""


### PR DESCRIPTION
## Summary

Commit 2 of the streaming plan in [`prd/streaming.md`](../blob/main/prd/streaming.md): replace the executor-bound collect helper with an async-native pipe from Modal straight to the Discord handler. **Behavior is unchanged** — the bot still posts a single final message per dispatch — but the plumbing is now ready for Commit 3 to slot the live status renderer on top without touching any sandbox code.

### `dispatcher.py`

- `SandboxDispatcher.run_task` becomes an `async def` that uses `yield` — an async generator returning `AsyncIterator[dict[str, Any]]`. Callers iterate with `async for`.
- Consumes `self._fn.remote_gen.aio(...)` so the stream lands on the event loop directly. The `asyncio.get_running_loop()` + `run_in_executor` dance from Commit 1 is deleted along with `_collect_events` and its done/error collection logic — that logic moves to the handler where it actually belongs.
- Log line at `dispatch.complete` now reports `event_count` instead of `output_length` — the dispatcher no longer constructs the output string, so a length field would be a lie.

### `handlers.py`

- `_dispatch_and_respond` drains `run_task` with `async for` inside the existing `async with thread.typing():` wrapper. Tracks `final_text` / `error_message` from the terminal `done` / `error` event and falls through to the same `_post_result` call as before.
- On an error event it reassembles `{final_text}\n\n[error]\n{message}` so Discord output matches Commit 1 byte-for-byte — intentional preservation, not a new behavior. Commit 3 rewrites this into the live-status driver.
- The generic "Something went wrong" catch-all around dispatcher exceptions is preserved unchanged.

### Deploy note

This PR **only touches the bot** (no sandbox changes). The deployed Modal function on main already emits the async-compatible generator — it just wasn't being consumed async yet. Paths filter in `.github/workflows/discord-orchestrator-deploy.yml` will skip the Modal redeploy and only rebuild + restart the bot container, which is the correct minimal blast radius for a bot-only change.

### Intentionally NOT in this PR

- `streaming.py` with the `_render` function and flush loop
- 1 edit/sec rate-limited status message
- Replacing `async with thread.typing()` with the live status message as the progress indicator
- Unit tests for `_flatten_stream_event` — still waiting on live-captured fixtures from a droplet run

## Test plan

- [ ] `cd apps/delulu_discord && make check`
- [ ] Merge — deploy workflow should skip `modal-deploy` (no sandbox changes) and only run `bot-deploy`. On main-as-today without #31 merged yet, the whole SSH script runs but the diff check inside it will skip the `make modal-deploy` branch since `apps/delulu_sandbox_modal/` is untouched
- [ ] Watch `docker logs -f disco` — bot container cycles clean, no new tracebacks
- [ ] **Smoke tests in Discord**, same three as Commit 1 (unchanged behavior is the whole point):
  - [ ] `@bot say hi in one sentence` — single message, normal content
  - [ ] `@bot read apps/delulu_discord/src/delulu_discord/dispatcher.py and tell me in one sentence what run_task does` — single message, multi-tool path still works
  - [ ] `@bot run this bash command: false` — single message with CC's normal narration, no `[error]` tail unless CC itself nonzero-exits
- [ ] **Watch bot logs for** `dispatch.complete ... event_count=<N>` where `N >= 1` on every run. If `event_count=0`, the async generator is terminating without yielding a single event and something is wrong at the Modal ↔ asyncio boundary (most likely `remote_gen.aio` API mismatch)
- [ ] **Watch bot logs for** `task.failed` — shouldn't fire on any of the three smoke tests. If it does, look at the traceback; likely an async iterator protocol mismatch

**Rollback one-liner if anything regresses:** `git checkout main && git revert --no-edit HEAD && git push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)