### PR TITLE
fix: pass valid kwargs to Message.edit in LiveStatus

### DIFF
--- a/apps/delulu_discord/pyproject.toml
+++ b/apps/delulu_discord/pyproject.toml
@@ -29,7 +29,11 @@ build-backend = "hatchling.build"
 packages = ["src/delulu_discord"]
 
 [tool.ruff]
-target-version = "py314"
+# Pinned to py313 (even though requires-python is >=3.14) so ruff's
+# formatter doesn't emit PEP 758 unparenthesized `except A, B:` syntax.
+# That form is valid in 3.14 but trips the claude-code-review autofix,
+# which treats it as a Python 2 SyntaxError and reverts every run.
+target-version = "py313"
 line-length = 100
 
 [tool.ruff.lint]

--- a/apps/delulu_discord/src/delulu_discord/handlers.py
+++ b/apps/delulu_discord/src/delulu_discord/handlers.py
@@ -93,7 +93,17 @@ class MessageHandler:
         On error the status message freezes on its last rendered state
         and a separate ``⚠️`` message carries the error details.
         """
-        status_msg = await thread.send(INITIAL_PLACEHOLDER)
+        # ``suppress_embeds`` is set here on the send — it's valid on
+        # ``Messageable.send`` but NOT on ``Message.edit`` in discord.py
+        # 2.4 (that's the crash that broke the initial Commit 3 ship).
+        # The flag sticks across edits, so setting it once at post time
+        # is enough to keep the live status from unfurling any URLs
+        # that might appear in tool summaries.
+        status_msg = await thread.send(
+            INITIAL_PLACEHOLDER,
+            allowed_mentions=discord.AllowedMentions.none(),
+            suppress_embeds=True,
+        )
         live = LiveStatus(status_msg)
         live.start()
 

--- a/apps/delulu_discord/src/delulu_discord/streaming.py
+++ b/apps/delulu_discord/src/delulu_discord/streaming.py
@@ -232,10 +232,17 @@ class LiveStatus:
             self._dirty = False
             return
         try:
+            # NOTE: do NOT pass ``suppress_embeds`` here — ``Message.edit``
+            # in discord.py 2.4 does not accept it and raises ``TypeError``
+            # on every edit, which used to crash the whole flush loop
+            # and then ``finalize_done``, leaving the status message
+            # stuck on the initial placeholder forever. The embed-
+            # suppressed flag is set once on the initial ``thread.send``
+            # in ``handlers._dispatch_and_respond`` and inherited by
+            # subsequent edits.
             await self.status_msg.edit(
                 content=rendered,
                 allowed_mentions=discord.AllowedMentions.none(),
-                suppress_embeds=True,
             )
             self._last_rendered = rendered
             self._dirty = False
@@ -260,12 +267,17 @@ class LiveStatus:
         self._flush_task = None
 
     async def _safe_edit(self, content: str) -> None:
+        # Same caveat as _flush_once: no ``suppress_embeds`` on edit.
         try:
             await self.status_msg.edit(
                 content=content,
                 allowed_mentions=discord.AllowedMentions.none(),
-                suppress_embeds=True,
             )
             self._last_rendered = content
         except discord.HTTPException:
+            logger.exception("streaming.edit_failed")
+        except Exception:
+            # Anything else (TypeError from a future kwarg mismatch,
+            # etc.) is a bug worth surfacing in logs but must not
+            # propagate out of finalize_done and break the handler.
             logger.exception("streaming.edit_failed")

--- a/apps/delulu_discord/tests/test_streaming.py
+++ b/apps/delulu_discord/tests/test_streaming.py
@@ -1,17 +1,26 @@
 """Unit tests for the live-status renderer in delulu_discord.streaming.
 
-These cover ``_render`` — a pure function that turns a list of event
-dicts into the markdown body of the status message. The flush loop
-itself is not tested here (it needs a fake Discord Message with an
-awaitable ``edit`` method and a running event loop); ``_render`` is
-where the interesting logic lives.
+Two groups of tests here:
+
+1. ``_render`` — a pure function from a list of event dicts to the
+   markdown body of the status message.
+2. ``LiveStatus`` edit plumbing — regression coverage for the
+   kwargs we pass to ``Message.edit``. The initial Commit 3 ship
+   crashed in production because ``suppress_embeds=True`` is valid
+   on ``Messageable.send`` but not on ``Message.edit`` in
+   discord.py 2.4, and the flush loop's ``TypeError`` propagated
+   out of ``finalize_done`` and stranded every run on the
+   "Thinking..." placeholder.
 """
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
 from delulu_discord.streaming import (
     DISCORD_MESSAGE_LIMIT,
     INITIAL_PLACEHOLDER,
+    LiveStatus,
     _render,
     render_done,
 )
@@ -145,3 +154,74 @@ def test_render_done_formatting() -> None:
     assert render_done(5, 8400) == "✅ Done • 5 tools • 8.4s"
     assert render_done(0, 0) == "✅ Done • 0 tools • 0.0s"
     assert render_done(1, 1234) == "✅ Done • 1 tools • 1.2s"
+
+
+# ── LiveStatus edit kwargs (regression) ─────────────────────────
+#
+# Commit 3 shipped with ``status_msg.edit(..., suppress_embeds=True)``,
+# which raises ``TypeError`` in discord.py 2.4 (``Message.edit`` does
+# not accept it — only ``Messageable.send`` does). The resulting
+# crash propagated out of ``finalize_done`` and left every run stuck
+# on the initial "Thinking..." placeholder. These tests lock in the
+# contract so the next accidental re-introduction fails in CI rather
+# than in prod.
+
+
+def _fake_message() -> MagicMock:
+    msg = MagicMock()
+    msg.edit = AsyncMock()
+    return msg
+
+
+async def test_flush_once_edit_kwargs_are_valid_for_message_edit() -> None:
+    msg = _fake_message()
+    live = LiveStatus(msg)
+    live.push({"type": "tool_use", "tool": "Read", "summary": "`a.py`"})
+    await live._flush_once()
+
+    msg.edit.assert_called_once()
+    call_kwargs = msg.edit.call_args.kwargs
+    assert "suppress_embeds" not in call_kwargs, (
+        "Message.edit does not accept suppress_embeds — set it on the "
+        "initial thread.send instead; the flag sticks across edits."
+    )
+    assert "content" in call_kwargs
+    assert "allowed_mentions" in call_kwargs
+
+
+async def test_safe_edit_kwargs_are_valid_for_message_edit() -> None:
+    """Used by finalize_done / finalize_error — same kwarg contract."""
+    msg = _fake_message()
+    live = LiveStatus(msg)
+    await live._safe_edit("some content")
+
+    msg.edit.assert_called_once()
+    call_kwargs = msg.edit.call_args.kwargs
+    assert "suppress_embeds" not in call_kwargs
+    assert call_kwargs["content"] == "some content"
+
+
+async def test_safe_edit_swallows_unexpected_errors() -> None:
+    """If a future kwarg mismatch re-introduces a TypeError on edit,
+    _safe_edit must NOT propagate it — otherwise finalize_done crashes
+    the handler the way Commit 3's initial ship did."""
+    msg = _fake_message()
+    msg.edit.side_effect = TypeError("unexpected keyword argument 'foo'")
+    live = LiveStatus(msg)
+
+    # Must not raise — the whole point of _safe_edit is to log and move on.
+    await live._safe_edit("content")
+    msg.edit.assert_called_once()
+
+
+async def test_flush_once_skips_edit_when_content_unchanged() -> None:
+    msg = _fake_message()
+    live = LiveStatus(msg)
+    live.push({"type": "text", "text": "hello"})
+
+    await live._flush_once()
+    assert msg.edit.call_count == 1
+
+    # No new events → _render output is unchanged → no redundant edit.
+    await live._flush_once()
+    assert msg.edit.call_count == 1

--- a/apps/delulu_sandbox_modal/pyproject.toml
+++ b/apps/delulu_sandbox_modal/pyproject.toml
@@ -22,7 +22,11 @@ build-backend = "hatchling.build"
 packages = ["src/delulu_sandbox_modal"]
 
 [tool.ruff]
-target-version = "py314"
+# Pinned to py313 (even though requires-python is >=3.14) so ruff's
+# formatter doesn't emit PEP 758 unparenthesized `except A, B:` syntax.
+# That form is valid in 3.14 but trips the claude-code-review autofix,
+# which treats it as a Python 2 SyntaxError and reverts every run.
+target-version = "py313"
 line-length = 100
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary

**Unblocks every Commit 3 dispatch.** The live-status renderer shipped in PR #33 has been stranding every run on the initial `💭 Thinking about your request...` placeholder because `suppress_embeds=True` is valid on `Messageable.send` but NOT on `Message.edit` in discord.py 2.4. Every flush raised:

```
TypeError: Message.edit() got an unexpected keyword argument 'suppress_embeds'
```

Observed on the droplet immediately after PR #33 deployed:

```
2026-04-14T05:08:42 dispatch.start session_id=03c8e7308bb2
2026-04-14T05:08:51 streaming.flush_failed
  TypeError: Message.edit() got an unexpected keyword argument 'suppress_embeds'
2026-04-14T05:08:52 dispatch.complete event_count=2
```

The background flush loop caught the `TypeError` and kept retrying — every iteration hit the same error. Worse, `finalize_done` called `_safe_edit` with the same bad kwargs, and `_safe_edit` only caught `discord.HTTPException` so the `TypeError` propagated out of `_dispatch_and_respond`. Net effect: no status collapse, no terminal `✅ Done` edit, no final-text message.

## Changes

### `streaming.py` — remove `suppress_embeds` from both edit call sites

- `_flush_once`: no longer passes `suppress_embeds=True`. Comment explains the kwarg is set once on the initial `thread.send` and inherited by edits.
- `_safe_edit`: same fix. Also adds a broad `except Exception:` catch in addition to `discord.HTTPException` — the whole point of that helper is log-and-move-on from edit failures during teardown. Any future kwarg mismatch (or network error outside the HTTPException hierarchy) must not propagate out of `finalize_done` and crash the handler the way this one did.

### `handlers.py` — set `suppress_embeds` on the initial send

```python
status_msg = await thread.send(
    INITIAL_PLACEHOLDER,
    allowed_mentions=discord.AllowedMentions.none(),
    suppress_embeds=True,
)
```

`Messageable.send` accepts `suppress_embeds`. The embed-suppressed flag sticks across edits, so this is equivalent to what the original code was trying to do — just at the correct API call.

### Regression tests

Four new tests in `test_streaming.py` lock in the edit kwarg contract so the next accidental re-introduction fails in CI instead of in prod. All use `AsyncMock` to fake `status_msg.edit`:

1. **`test_flush_once_edit_kwargs_are_valid_for_message_edit`** — asserts `suppress_embeds` is NOT in the edit's kwargs and `content` + `allowed_mentions` are
2. **`test_safe_edit_kwargs_are_valid_for_message_edit`** — same contract for the terminal edit path used by `finalize_done` / `finalize_error`
3. **`test_safe_edit_swallows_unexpected_errors`** — wires a `TypeError` into the mock's `side_effect` and asserts `_safe_edit` returns normally. This is what would have saved the handler from the prod crash
4. **`test_flush_once_skips_edit_when_content_unchanged`** — locks in the `_last_rendered` short-circuit so we don't burn Discord edits on no-op refreshes

Total streaming tests: 13 render + 4 LiveStatus = **17**, all passing locally (`make -C apps/delulu_discord test`).

## Also in this PR — `ci: pin ruff target-version to py313`

Duplicated from the still-open PR #35, because this fix needs the pin to stay stable across CI runs. Without it, `ruff format` with `target-version = "py314"` converts parenthesized `except (A, B):` into PEP 758 `except A, B:` form, which the `claude-code-review` autofix treats as a Python 2 `SyntaxError` and reverts every run → infinite ping-pong on the branch.

Pin is the lowest-drama exit: the formatter stops emitting PEP 758 syntax, the autofix stays silent, and the actual Python (3.14 in the Docker + Modal images) is unchanged because parenthesized tuple `except` has worked since 2.6. `requires-python = ">=3.14"` at the project level stays put.

**PR #35 overlaps.** Once this fix lands, PR #35 can be rebased and its `ci: pin ruff target-version…` commit dropped (keeping only the parser tests). I'll do that rebase after merge.

## Test plan

- [x] `cd apps/delulu_discord && make check && make test` — 17/17 passing
- [x] `cd apps/delulu_sandbox_modal && make check` — clean
- [x] Regression test asserts the exact kwarg pattern that broke prod
- [ ] Merge → bot rebuilds → send `@bot say hi` → status message posts → after a beat, collapses to `✅ Done • 0 tools • Xs` → final message appears below. **That's the acceptance signal.**
- [ ] Multi-tool prompt (e.g. `@bot read apps/delulu_discord/src/delulu_discord/handlers.py and summarize in one line`) → tool lines stream in with `✓` marks → `✍️  Writing response...` → `✅ Done`
- [ ] `docker logs disco | grep streaming.flush_failed` — should return empty. A single `streaming.rate_limited` would be fine (1 edit/sec is aggressive); multiple are worth looking at

**Deploy note.** Bot-only change, Modal function untouched. The deploy workflow's paths filter will skip `modal-deploy` and only rebuild the bot container.

**Rollback.** If this fix somehow introduces a new problem, reverting it + PR #33 together gets you back to Commit 2's single-final-message behavior which is known working:

```
git revert --no-edit <this-merge-sha> <pr-33-merge-sha> && git push
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)