### PR TITLE
ci: extract review prompt to pr-review skill file

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pr-review
+name: code-review
 description: Review a pull request for the SMILE-factory monorepo. Produces exactly one advisory PR review (approve or comment, never request-changes) via `gh pr review --body-file`. Mirrors the multi-step, high-signal approach from anthropics/claude-code's code-review plugin but scoped to the delulu Discord orchestrator architecture.
 ---
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: pr-review
+description: Review a pull request for the SMILE-factory monorepo. Produces exactly one advisory PR review (approve or comment, never request-changes) via `gh pr review --body-file`. Mirrors the multi-step, high-signal approach from anthropics/claude-code's code-review plugin but scoped to the delulu Discord orchestrator architecture.
+---
+
+# PR review — SMILE-factory
+
+You are reviewing a pull request in the SMILE-factory monorepo. The
+process below is adapted from the `code-review` plugin in
+`anthropics/claude-code` (the canonical high-signal PR reviewer),
+with three project-specific adaptations:
+
+1. Scoped to the delulu Discord orchestrator architecture and its
+   boundary invariants (see below).
+2. **Approve-or-comment only.** Never `--request-changes`.
+3. Submits exactly one top-level formal review via `gh pr review
+   --body-file`, rather than posting inline comments. Our workflow
+   wires the review into GitHub's Reviewers box so branch protection
+   can gate on it.
+
+## Repository context
+
+The active project is the **delulu Discord orchestrator**:
+
+- `apps/delulu_discord` — Discord bot, runs in Docker on a VPS.
+  Changes here require a bot container rebuild.
+- `apps/delulu_sandbox_modal` — Modal sandbox function that runs
+  Claude Code. Changes here require a Modal redeploy.
+
+The repo root also contains archived LoRA-Instruct fine-tuning code.
+Lower review priority unless the PR explicitly touches it.
+
+**Boundary invariants that the code must respect** (treat violations
+as correctness issues):
+
+- `delulu_discord` must never import from `delulu_sandbox_modal`
+  (deployed separately).
+- `delulu_sandbox_modal` must never import bot-side Discord types.
+
+## Review process
+
+### Step 1 — Pre-flight
+
+Decide whether this PR should be reviewed at all. **Skip review** if
+any of these are true:
+
+- The PR is a draft or closed
+- The only changes are under `prd/` (planning docs, not production code)
+- The only changes are documentation wording fixes
+
+If skipping, write a one-line "skipped — reason" note to
+`/tmp/review.md` and submit a single `gh pr review <N> --comment
+--body-file /tmp/review.md`. Then stop.
+
+### Step 2 — Load PR context
+
+Fetch PR metadata and the diff via WebFetch against the GitHub REST
+API (not via bash, not via local git):
+
+- `https://api.github.com/repos/<owner>/<repo>/pulls/<N>` for
+  metadata (title, body, author, base/head SHAs)
+- `https://api.github.com/repos/<owner>/<repo>/pulls/<N>/files` for
+  the file list and patches
+
+Note any `CLAUDE.md` files at the repo root and in directories
+touched by the PR. They define project conventions you should check
+against. A `CLAUDE.md` file only applies to files in its directory
+tree — don't enforce a `apps/delulu_discord/CLAUDE.md` rule against
+a `apps/delulu_sandbox_modal/` file.
+
+### Step 3 — Review in priority order
+
+Evaluate the diff in this order. Only flag real, high-confidence
+issues. Do not speculate.
+
+**Priority 1 — Correctness.** Actual bugs that will break the code.
+Focus on:
+
+- Compile/parse errors: syntax errors, type errors, missing imports,
+  unresolved references
+- Clear logic errors that produce wrong results regardless of inputs
+- Missing error handling at system boundaries: Discord gateway
+  callbacks, Modal dispatch, subprocess exec, async generator
+  cleanup
+- Async/await misuse (e.g., `asyncio.get_event_loop()` inside
+  `async def` when `get_running_loop()` is correct)
+
+**Priority 2 — Security.** Credential handling, path traversal in
+the attachment-write path, subprocess argument injection, anything
+that widens the Modal sandbox's blast radius.
+
+**Priority 3 — Boundary invariants.** Cross-boundary imports between
+the bot and the sandbox. Violations are correctness issues.
+
+**Priority 4 — Deployment impact.** If the PR touches
+`apps/delulu_sandbox_modal/`, a Modal redeploy is needed. If it
+touches `apps/delulu_discord/`, a bot container rebuild is needed.
+Flag if the PR description or commit messages don't mention which
+side is affected when the change spans both.
+
+**Priority 5 — Test coverage.** Note missing tests but **do not
+block on them** — the project has minimal test infrastructure today.
+
+### Step 4 — High-signal filter
+
+**Only keep issues that clear all of these bars:**
+
+- The code will fail to compile, parse, or run correctly **regardless
+  of inputs**, OR
+- There is a **clear, quotable violation of a rule** in a scoped
+  `CLAUDE.md` file, OR
+- The change introduces a **specific, demonstrable security
+  regression**
+
+**Filter OUT:**
+
+- Style nits that ruff would catch — ruff runs in pre-commit
+- Documentation wording unless factually wrong
+- General "code quality" concerns
+- Potential issues that depend on unknown inputs or external state
+- Subjective suggestions and improvements
+- Pre-existing issues (things that already exist on the base branch)
+
+If you are not certain an issue is real, **do not flag it.** False
+positives erode trust and waste reviewer time.
+
+### Step 5 — Write the review body
+
+Use the `Write` tool to save the review body to `/tmp/review.md`.
+**Do not use shell heredoc (`cat > file <<EOF`)** — markdown with
+code fences and backticks collides with bash quoting, which has
+caused duplicate-review pollution in the past.
+
+Body format:
+
+```markdown
+## Review summary
+
+<one-sentence verdict: "LGTM", "minor observations", or
+"flagging N issues for human review">
+
+## Findings
+
+<list of high-signal issues grouped by priority. Only include this
+section if there are findings. Each finding should include file +
+line range, the issue, and why it's high-signal. Skip this section
+entirely if no findings.>
+
+## Deployment
+
+<which side(s) need a redeploy/rebuild, if any. Skip this section
+if the PR doesn't touch either app.>
+```
+
+Keep the body concise. Do not manufacture content to fill space.
+
+### Step 6 — Submit exactly one review
+
+**Your review is advisory, not blocking.** Pick exactly one of:
+
+- No substantive issues →
+  `gh pr review <N> --approve --body-file /tmp/review.md`
+- Issues / observations / questions →
+  `gh pr review <N> --comment --body-file /tmp/review.md`
+
+**Do not use `--request-changes`.** A request-changes review gives
+your individual judgment a hard veto over merges, and you can be
+wrong. High-confidence findings still go in the comment body — the
+human reviewer decides whether they block merge.
+
+**Never retry on apparent failure.** One attempt, one outcome.
+Duplicate reviews pollute the PR history.
+
+**The only permitted fallback:** if `gh pr review <N> --approve`
+fails with a "cannot approve your own pull request" error, fall
+back to `gh pr review <N> --comment --body-file /tmp/review.md`
+with the same body file. One retry maximum, only for this specific
+error.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,8 +51,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      # Load the review instructions from the pr-review skill file.
-      # Keeping the prompt in `.claude/skills/pr-review/SKILL.md`
+      # Load the review instructions from the code-review skill file.
+      # Keeping the prompt in `.claude/skills/code-review/SKILL.md`
       # means it's versioned, editable as plain markdown, renders in
       # the GitHub file viewer, and is ALSO discoverable by `claude`
       # running interactively against this repo (the file uses the
@@ -61,7 +61,7 @@ jobs:
       # prompt — we don't rely on claude-code-action auto-loading
       # skills from `.claude/skills/`, because that path isn't
       # verified to work in agent mode.
-      - name: Load pr-review skill
+      - name: Load code-review skill
         id: skill
         run: |
           {
@@ -69,7 +69,7 @@ jobs:
             # Strip YAML frontmatter: skip everything up to and
             # including the second `---` line, then print the rest.
             awk 'BEGIN{c=0} /^---$/{c++; next} c>=2{print}' \
-              .claude/skills/pr-review/SKILL.md
+              .claude/skills/code-review/SKILL.md
             echo ''
             echo '---'
             echo ''
@@ -122,8 +122,8 @@ jobs:
           # WebFetch tool against the GitHub REST API, so we don't
           # need to whitelist `gh pr view`.
           claude_args: --allowedTools "Write,Bash(gh pr review:*)"
-          # The review prompt lives in .claude/skills/pr-review/SKILL.md
-          # and is loaded by the preceding "Load pr-review skill" step.
+          # The review prompt lives in .claude/skills/code-review/SKILL.md
+          # and is loaded by the preceding "Load code-review skill" step.
           # Edit that file to change review behavior; don't inline
           # prompt content here.
           prompt: ${{ steps.skill.outputs.prompt }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,6 +51,35 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Load the review instructions from the pr-review skill file.
+      # Keeping the prompt in `.claude/skills/pr-review/SKILL.md`
+      # means it's versioned, editable as plain markdown, renders in
+      # the GitHub file viewer, and is ALSO discoverable by `claude`
+      # running interactively against this repo (the file uses the
+      # Claude Code skill frontmatter format). The workflow strips
+      # the YAML frontmatter and passes the body as the inline
+      # prompt — we don't rely on claude-code-action auto-loading
+      # skills from `.claude/skills/`, because that path isn't
+      # verified to work in agent mode.
+      - name: Load pr-review skill
+        id: skill
+        run: |
+          {
+            echo 'prompt<<SKILL_EOF'
+            # Strip YAML frontmatter: skip everything up to and
+            # including the second `---` line, then print the rest.
+            awk 'BEGIN{c=0} /^---$/{c++; next} c>=2{print}' \
+              .claude/skills/pr-review/SKILL.md
+            echo ''
+            echo '---'
+            echo ''
+            echo '## Invocation context'
+            echo ''
+            echo 'PR number: ${{ github.event.pull_request.number }}'
+            echo 'Repository: ${{ github.repository }}'
+            echo 'SKILL_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -93,76 +122,8 @@ jobs:
           # WebFetch tool against the GitHub REST API, so we don't
           # need to whitelist `gh pr view`.
           claude_args: --allowedTools "Write,Bash(gh pr review:*)"
-          prompt: |
-            You are reviewing a pull request in the SMILE-factory monorepo.
-
-            The active project is the **delulu Discord orchestrator** under
-            `apps/delulu_discord` (bot, runs in Docker on a VPS) and
-            `apps/delulu_sandbox_modal` (Modal sandbox function that runs
-            Claude Code). The root also contains archived LoRA-Instruct
-            fine-tuning code — lower priority for review unless the PR
-            explicitly touches it.
-
-            Focus your review on, in priority order:
-              1. **Correctness** — actual bugs, broken flows, missing
-                 error handling at system boundaries (Discord gateway,
-                 Modal dispatch, subprocess exec).
-              2. **Security** — credential handling, path traversal in the
-                 attachment-write path, subprocess argument injection,
-                 anything that widens the Modal sandbox's blast radius.
-              3. **Boundary invariants** — the bot must never import from
-                 `delulu_sandbox_modal` (they're deployed separately); the
-                 sandbox must never import bot-side Discord types. Flag any
-                 cross-boundary imports.
-              4. **Deployment impact** — changes under
-                 `apps/delulu_sandbox_modal/` require a Modal redeploy;
-                 changes under `apps/delulu_discord/` require a bot
-                 container rebuild. Flag if the PR description or commit
-                 messages don't mention which side is affected.
-              5. **Test coverage gaps** — note missing tests, but don't
-                 block on them (the project has minimal test infrastructure
-                 today).
-
-            Do **not** comment on:
-              - Style nits that ruff would catch (ruff runs in pre-commit)
-              - Documentation wording unless it's factually wrong
-              - Changes to PRDs under `prd/` — those are planning docs,
-                not production code
-
-            Be concise. Do not manufacture feedback to fill space.
-
-            **Your review is advisory, not blocking.** You have exactly
-            two outcomes to choose from:
-
-            - No substantive issues → `--approve`
-            - Anything else (observations, concerns, questions, bugs
-              you want a human to confirm) → `--comment`
-
-            Do **NOT** use `--request-changes`. A request-changes review
-            gives your individual judgment a hard veto over merges, and
-            you can be wrong. Findings you think are important still go
-            in the `--comment` body — the human reviewer decides whether
-            they block merge. Approve-or-comment is the right shape for
-            an AI code reviewer.
-
-            **Submit exactly ONE PR review at the end of the run.
-            Never retry on apparent failure — one attempt, one
-            outcome.** Duplicate reviews pollute the PR history. The
-            PR number is `${{ github.event.pull_request.number }}`.
-
-            **How to submit** — use the `Write` tool to save your
-            review body to `/tmp/review.md`, then call `gh pr review`
-            with `--body-file`. Do **not** pass the body inline via
-            `--body "..."`: markdown with code fences, backticks, and
-            newlines collides with bash quoting, the first attempt
-            gets mangled, and any retry pollutes the review history.
-
-            - No substantive issues →
-              `gh pr review <N> --approve --body-file /tmp/review.md`
-            - Issues / observations / questions →
-              `gh pr review <N> --comment --body-file /tmp/review.md`
-
-            If `gh pr review --approve` fails with a "cannot approve
-            your own pull request" error, fall back to `--comment`
-            with the same body file (one retry maximum, only for this
-            specific error — never retry for any other reason).
+          # The review prompt lives in .claude/skills/pr-review/SKILL.md
+          # and is loaded by the preceding "Load pr-review skill" step.
+          # Edit that file to change review behavior; don't inline
+          # prompt content here.
+          prompt: ${{ steps.skill.outputs.prompt }}


### PR DESCRIPTION
## Summary
Moves the PR review prompt out of \`claude-code-review.yml\` and into \`.claude/skills/pr-review/SKILL.md\`. The workflow's \"Load pr-review skill\" step reads the file, strips the YAML frontmatter, and passes the body as the inline prompt to claude-code-action.

## Why
- **Prompt lives in a file**, versioned and editable as plain markdown. Renders in GitHub's file viewer without YAML escaping getting in the way
- **Workflow YAML shrinks from 209 lines to 80 lines** — most of the delta is the prompt body moving out
- **File uses Claude Code's skill frontmatter format**, so running \`claude\` interactively against this repo will also discover it. Same file, two invocation paths
- **Prompt structure mirrors anthropics/claude-code's \`code-review\` plugin** (the canonical high-signal reviewer), adapted with three project-specific changes: scoped to the delulu Discord/Modal architecture and its boundary invariants, approve-or-comment only (no \`--request-changes\`), and submits one top-level review via \`gh pr review --body-file\` rather than inline line-comments

## Honest caveat
I didn't verify that claude-code-action natively auto-loads skills from \`.claude/skills/\` in agent mode. The Skill tool isn't in the default allowlist we've been setting, and CI-mode skill discovery isn't documented anywhere I could find. So the workflow uses a **pragmatic hybrid**: shell-load the file in a preceding step, pass the body as the inline prompt. Structurally the file is still a valid skill and behaves as one under interactive \`claude\` use — we're just not relying on an unverified auto-loading path for the CI case.

If Anthropic ships first-class skill-loading for claude-code-action later, the migration is one-line: delete the \"Load pr-review skill\" step and replace \`prompt: \${{ steps.skill.outputs.prompt }}\` with \`prompt: 'Use the pr-review skill to review PR \${{ github.event.pull_request.number }}'\`.

## Test plan
- [ ] Merge (OIDC dance)
- [ ] On any real PR, confirm the review job still submits exactly one review (approve or comment) with the same behavior as before the extraction
- [ ] Edit \`.claude/skills/pr-review/SKILL.md\` in a follow-up PR and confirm the review behavior changes as expected — proves the file is actually driving the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)