### PR TITLE
ci: set up local code-review plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "smile-factory",
+  "owner": {
+    "name": "leehanchung"
+  },
+  "plugins": [
+    {
+      "name": "code-review",
+      "source": "./plugins/code-review",
+      "description": "Advisory PR code review scoped to the SMILE-factory monorepo. Approve-or-comment only (never request-changes), submits one formal review via `gh pr review --body-file`.",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,92 +77,18 @@ jobs:
           # message) when the reviewer comment doesn't show up on a PR.
           # Flip back to false once review behavior is stable.
           show_full_output: true
-          # Whitelist the tools needed to submit a PR review:
-          #   - Bash(gh pr review:*): the actual review submission.
-          #     Narrow prefix match; no other gh subcommands are allowed.
-          #   - Write: lets the agent drop the review body into a temp
-          #     file so we can use `gh pr review --body-file` instead
-          #     of inline `--body "..."`. The inline form collides
-          #     with bash quoting whenever the review body contains
-          #     code fences or backticks, and the agent ends up
-          #     retrying with progressively shorter bodies — polluting
-          #     the review history with 4-5 reviews per run. File-
-          #     based submission sidesteps that entirely.
+          # Load our local code-review plugin from this repo's
+          # `.claude-plugin/marketplace.json`. The plugin's slash
+          # command lives at `plugins/code-review/commands/code-review.md`
+          # and its allowed tools (Write, WebFetch, Bash(gh pr review:*))
+          # are declared in that file's frontmatter.
           #
-          # Reading PR metadata/diff works via the default-allowed
-          # WebFetch tool against the GitHub REST API, so we don't
-          # need to whitelist `gh pr view`.
-          claude_args: --allowedTools "Write,Bash(gh pr review:*)"
-          prompt: |
-            You are reviewing a pull request in the SMILE-factory monorepo.
-
-            The active project is the **delulu Discord orchestrator** under
-            `apps/delulu_discord` (bot, runs in Docker on a VPS) and
-            `apps/delulu_sandbox_modal` (Modal sandbox function that runs
-            Claude Code). The root also contains archived LoRA-Instruct
-            fine-tuning code — lower priority for review unless the PR
-            explicitly touches it.
-
-            Focus your review on, in priority order:
-              1. **Correctness** — actual bugs, broken flows, missing
-                 error handling at system boundaries (Discord gateway,
-                 Modal dispatch, subprocess exec).
-              2. **Security** — credential handling, path traversal in the
-                 attachment-write path, subprocess argument injection,
-                 anything that widens the Modal sandbox's blast radius.
-              3. **Boundary invariants** — the bot must never import from
-                 `delulu_sandbox_modal` (they're deployed separately); the
-                 sandbox must never import bot-side Discord types. Flag any
-                 cross-boundary imports.
-              4. **Deployment impact** — changes under
-                 `apps/delulu_sandbox_modal/` require a Modal redeploy;
-                 changes under `apps/delulu_discord/` require a bot
-                 container rebuild. Flag if the PR description or commit
-                 messages don't mention which side is affected.
-              5. **Test coverage gaps** — note missing tests, but don't
-                 block on them (the project has minimal test infrastructure
-                 today).
-
-            Do **not** comment on:
-              - Style nits that ruff would catch (ruff runs in pre-commit)
-              - Documentation wording unless it's factually wrong
-              - Changes to PRDs under `prd/` — those are planning docs,
-                not production code
-
-            Be concise. Do not manufacture feedback to fill space.
-
-            **Your review is advisory, not blocking.** You have exactly
-            two outcomes to choose from:
-
-            - No substantive issues → `--approve`
-            - Anything else (observations, concerns, questions, bugs
-              you want a human to confirm) → `--comment`
-
-            Do **NOT** use `--request-changes`. A request-changes review
-            gives your individual judgment a hard veto over merges, and
-            you can be wrong. Findings you think are important still go
-            in the `--comment` body — the human reviewer decides whether
-            they block merge. Approve-or-comment is the right shape for
-            an AI code reviewer.
-
-            **Submit exactly ONE PR review at the end of the run.
-            Never retry on apparent failure — one attempt, one
-            outcome.** Duplicate reviews pollute the PR history. The
-            PR number is `${{ github.event.pull_request.number }}`.
-
-            **How to submit** — use the `Write` tool to save your
-            review body to `/tmp/review.md`, then call `gh pr review`
-            with `--body-file`. Do **not** pass the body inline via
-            `--body "..."`: markdown with code fences, backticks, and
-            newlines collides with bash quoting, the first attempt
-            gets mangled, and any retry pollutes the review history.
-
-            - No substantive issues →
-              `gh pr review <N> --approve --body-file /tmp/review.md`
-            - Issues / observations / questions →
-              `gh pr review <N> --comment --body-file /tmp/review.md`
-
-            If `gh pr review --approve` fails with a "cannot approve
-            your own pull request" error, fall back to `--comment`
-            with the same body file (one retry maximum, only for this
-            specific error — never retry for any other reason).
+          # Gotcha: claude-code-action fetches the plugin from the
+          # default branch of the URL, NOT from the checked-out tree.
+          # So edits to `plugins/code-review/` on a PR branch won't be
+          # exercised by that same PR's review. Changes take effect
+          # only after they land on `main` — same self-validation
+          # caveat as the workflow files themselves.
+          plugin_marketplaces: 'https://github.com/leehanchung/SMILE-factory.git'
+          plugins: 'code-review@smile-factory'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "code-review",
+  "description": "Advisory PR code review scoped to the SMILE-factory monorepo. Approve-or-comment only (never request-changes), submits one formal review via `gh pr review --body-file`.",
+  "version": "0.1.0",
+  "author": {
+    "name": "leehanchung"
+  }
+}

--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -1,0 +1,62 @@
+# code-review plugin
+
+A Claude Code plugin that performs an advisory PR code review scoped
+to the SMILE-factory monorepo.
+
+## What it does
+
+Invokes `/code-review:code-review <repo>/pull/<N>` and produces
+**exactly one** formal GitHub PR review via `gh pr review
+--body-file`. Outcomes are limited to:
+
+- `--approve` — no substantive issues
+- `--comment` — anything else (observations, concerns, questions,
+  high-confidence bugs the human should confirm)
+
+**Never `--request-changes`.** A model's judgment shouldn't hard-
+veto merges; the human decides what blocks.
+
+## Where it's used
+
+Called from `.github/workflows/claude-code-review.yml` on every
+`pull_request` event (excluding drafts and PRs authored by
+`claude[bot]`). See that workflow file for the exact
+`plugin_marketplaces` / `plugins` / `prompt` wiring.
+
+You can also invoke it interactively if you run `claude` against
+this repo:
+
+```
+/code-review:code-review leehanchung/SMILE-factory/pull/42
+```
+
+## Review scope
+
+See `commands/code-review.md` for the full prompt. Highlights:
+
+- **Priority 1** — Correctness (compile errors, logic errors, async
+  misuse, boundary error handling)
+- **Priority 2** — Security (credential handling, path traversal,
+  subprocess argument injection, sandbox blast radius)
+- **Priority 3** — Boundary invariants (no cross-imports between
+  `delulu_discord` and `delulu_sandbox_modal`)
+- **Priority 4** — Deployment impact (Modal redeploy / bot
+  container rebuild when touching the apps)
+- **Priority 5** — Test coverage (noted but non-blocking)
+
+High-signal filter explicitly excludes style nits, pre-existing
+issues, subjective suggestions, and anything that depends on
+unknown inputs or external state.
+
+## Editing this plugin
+
+One gotcha: the GitHub Action fetches this plugin from the
+**default branch** of the repo URL passed to `plugin_marketplaces`.
+When `plugin_marketplaces` points at this repo, **edits to this
+plugin take effect only after they land on `main`** — a PR that
+edits the plugin won't exercise its own changes. Same
+self-validation caveat as the workflow files themselves.
+
+To test a plugin edit: merge it to `main` (bypass any blocked
+checks if needed, the plugin is the thing being tested), then
+exercise the new behavior on a follow-up PR.

--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -1,0 +1,178 @@
+---
+description: Review a pull request for the SMILE-factory monorepo. Produces exactly one advisory PR review (approve or comment, never request-changes) via `gh pr review --body-file`.
+allowed-tools: Write, WebFetch, Bash(gh pr review:*)
+---
+
+# PR review — SMILE-factory
+
+You are reviewing a pull request in the SMILE-factory monorepo. This
+command is adapted from the `code-review` plugin in
+`anthropics/claude-code` (the canonical high-signal PR reviewer),
+with three project-specific adaptations:
+
+1. Scoped to the delulu Discord orchestrator architecture and its
+   boundary invariants (see below).
+2. **Approve-or-comment only.** Never `--request-changes`.
+3. Submits exactly one top-level formal review via `gh pr review
+   --body-file`, rather than posting inline comments. Our workflow
+   wires the review into GitHub's Reviewers box so branch protection
+   can gate on it.
+
+## Repository context
+
+The active project is the **delulu Discord orchestrator**:
+
+- `apps/delulu_discord` — Discord bot, runs in Docker on a VPS.
+  Changes here require a bot container rebuild.
+- `apps/delulu_sandbox_modal` — Modal sandbox function that runs
+  Claude Code. Changes here require a Modal redeploy.
+
+The repo root also contains archived LoRA-Instruct fine-tuning code.
+Lower review priority unless the PR explicitly touches it.
+
+**Boundary invariants that the code must respect** (treat violations
+as correctness issues):
+
+- `delulu_discord` must never import from `delulu_sandbox_modal`
+  (deployed separately).
+- `delulu_sandbox_modal` must never import bot-side Discord types.
+
+## Review process
+
+### Step 1 — Pre-flight
+
+Decide whether this PR should be reviewed at all. **Skip review** if
+any of these are true:
+
+- The PR is a draft or closed
+- The only changes are under `prd/` (planning docs, not production code)
+- The only changes are documentation wording fixes
+
+If skipping, write a one-line "skipped — reason" note to
+`/tmp/review.md` and submit a single `gh pr review <N> --comment
+--body-file /tmp/review.md`. Then stop.
+
+### Step 2 — Load PR context
+
+Fetch PR metadata and the diff via WebFetch against the GitHub REST
+API (not via bash, not via local git):
+
+- `https://api.github.com/repos/<owner>/<repo>/pulls/<N>` for
+  metadata (title, body, author, base/head SHAs)
+- `https://api.github.com/repos/<owner>/<repo>/pulls/<N>/files` for
+  the file list and patches
+
+Note any `CLAUDE.md` files at the repo root and in directories
+touched by the PR. They define project conventions you should check
+against. A `CLAUDE.md` file only applies to files in its directory
+tree — don't enforce `apps/delulu_discord/CLAUDE.md` rules against
+a `apps/delulu_sandbox_modal/` file.
+
+### Step 3 — Review in priority order
+
+Evaluate the diff in this order. Only flag real, high-confidence
+issues. Do not speculate.
+
+**Priority 1 — Correctness.** Actual bugs that will break the code.
+Focus on:
+
+- Compile/parse errors: syntax errors, type errors, missing imports,
+  unresolved references
+- Clear logic errors that produce wrong results regardless of inputs
+- Missing error handling at system boundaries: Discord gateway
+  callbacks, Modal dispatch, subprocess exec, async generator
+  cleanup
+- Async/await misuse (e.g., `asyncio.get_event_loop()` inside
+  `async def` when `get_running_loop()` is correct)
+
+**Priority 2 — Security.** Credential handling, path traversal in
+the attachment-write path, subprocess argument injection, anything
+that widens the Modal sandbox's blast radius.
+
+**Priority 3 — Boundary invariants.** Cross-boundary imports between
+the bot and the sandbox. Violations are correctness issues.
+
+**Priority 4 — Deployment impact.** If the PR touches
+`apps/delulu_sandbox_modal/`, a Modal redeploy is needed. If it
+touches `apps/delulu_discord/`, a bot container rebuild is needed.
+Flag if the PR description or commit messages don't mention which
+side is affected when the change spans both.
+
+**Priority 5 — Test coverage.** Note missing tests but **do not
+block on them** — the project has minimal test infrastructure today.
+
+### Step 4 — High-signal filter
+
+**Only keep issues that clear all of these bars:**
+
+- The code will fail to compile, parse, or run correctly **regardless
+  of inputs**, OR
+- There is a **clear, quotable violation of a rule** in a scoped
+  `CLAUDE.md` file, OR
+- The change introduces a **specific, demonstrable security
+  regression**
+
+**Filter OUT:**
+
+- Style nits that ruff would catch — ruff runs in pre-commit
+- Documentation wording unless factually wrong
+- General "code quality" concerns
+- Potential issues that depend on unknown inputs or external state
+- Subjective suggestions and improvements
+- Pre-existing issues (things that already exist on the base branch)
+
+If you are not certain an issue is real, **do not flag it.** False
+positives erode trust and waste reviewer time.
+
+### Step 5 — Write the review body
+
+Use the `Write` tool to save the review body to `/tmp/review.md`.
+**Do not use shell heredoc (`cat > file <<EOF`)** — markdown with
+code fences and backticks collides with bash quoting, which has
+caused duplicate-review pollution in the past.
+
+Body format:
+
+```markdown
+## Review summary
+
+<one-sentence verdict: "LGTM", "minor observations", or
+"flagging N issues for human review">
+
+## Findings
+
+<list of high-signal issues grouped by priority. Only include this
+section if there are findings. Each finding should include file +
+line range, the issue, and why it's high-signal. Skip this section
+entirely if no findings.>
+
+## Deployment
+
+<which side(s) need a redeploy/rebuild, if any. Skip this section
+if the PR doesn't touch either app.>
+```
+
+Keep the body concise. Do not manufacture content to fill space.
+
+### Step 6 — Submit exactly one review
+
+**Your review is advisory, not blocking.** Pick exactly one of:
+
+- No substantive issues →
+  `gh pr review <N> --approve --body-file /tmp/review.md`
+- Issues / observations / questions →
+  `gh pr review <N> --comment --body-file /tmp/review.md`
+
+**Do not use `--request-changes`.** A request-changes review gives
+your individual judgment a hard veto over merges, and you can be
+wrong. High-confidence findings still go in the comment body — the
+human reviewer decides whether they block merge.
+
+**Never retry on apparent failure.** One attempt, one outcome.
+Duplicate reviews pollute the PR history.
+
+**The only permitted fallback:** if `gh pr review <N> --approve`
+fails with a "cannot approve your own pull request" error, fall
+back to `gh pr review <N> --comment --body-file /tmp/review.md`
+with the same body file. One retry maximum, only for this specific
+error.


### PR DESCRIPTION
## Summary
Sets up a local Claude Code plugin marketplace at the repo root, mirroring the layout of \`anthropics/claude-code/plugins/code-review/\`. The PR review prompt moves out of \`claude-code-review.yml\` and into \`plugins/code-review/commands/code-review.md\` as a slash command invoked via \`/code-review:code-review\`.

## Why this instead of the skill approach from #37
Research on \`anthropics/claude-code-action\` confirms that native \`.claude/skills/\` auto-loading doesn't work in the action today — issues [#1003](https://github.com/anthropics/claude-code-action/issues/1003) and [#1145](https://github.com/anthropics/claude-code-action/issues/1145) document this. Slash commands via \`plugin_marketplaces\` is the path that's actually known to work (it's what benchflow-ai/skillsbench uses, and the action's \`install-plugins.ts\` shells out to \`claude plugin marketplace add\` which handles the git fetch and plugin registration).

Close #37 in favor of this if you want to go with plugins. The skill file and plugin command have identical prompt content — just different delivery mechanisms.

## File layout
\`\`\`
.claude-plugin/marketplace.json           — marketplace manifest (name: smile-factory)
plugins/code-review/
  .claude-plugin/plugin.json              — plugin manifest
  commands/code-review.md                 — slash command (frontmatter declares Write, WebFetch, Bash(gh pr review:*))
  README.md                               — plugin readme with usage + self-validation caveat
\`\`\`

## Workflow changes
- Removes ~80 lines of inline \`prompt:\` body
- Removes \`claude_args --allowedTools\` (command frontmatter owns the tool list now)
- Adds \`plugin_marketplaces: 'https://github.com/leehanchung/SMILE-factory.git'\`
- Adds \`plugins: 'code-review@smile-factory'\`
- \`prompt:\` becomes a single slash command invocation

## Self-validation caveat (important)
\`claude-code-action\` fetches the plugin from the **default branch** of the URL, not from the checked-out tree. Edits to \`plugins/code-review/\` on a PR branch won't be exercised by that same PR's review — changes only take effect after they land on \`main\`. Documented in both the workflow comment and the plugin README so future-me doesn't lose an hour.

## Test plan
- [ ] Merge this (OIDC dance — same as usual)
- [ ] On the next real PR, confirm the review job runs the slash command, the plugin loads, and exactly one formal review gets posted (\`--approve\` or \`--comment\`, never \`--request-changes\`)
- [ ] Check the workflow logs for the plugin fetch step and confirm no errors
- [ ] Edit \`plugins/code-review/commands/code-review.md\` in a follow-up PR, merge to main, then exercise on a subsequent PR to verify the new behavior takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)