### PR TITLE
feat: bot-side repo binding plumbing (phase 2)

### DIFF
--- a/apps/delulu_discord/src/delulu_discord/dispatcher.py
+++ b/apps/delulu_discord/src/delulu_discord/dispatcher.py
@@ -37,9 +37,11 @@ class SandboxDispatcher:
     async def run_task(
         self,
         session_id: str,
-        workspace_path: str,
+        thread_id: int,
         prompt: str,
         *,
+        repo_url: str | None = None,
+        ref: str = "HEAD",
         resume: bool = False,
         attachments: list[tuple[str, bytes]] | None = None,
         message_id: int | None = None,
@@ -54,12 +56,22 @@ class SandboxDispatcher:
         ``dict[str, Any]`` here). The terminal event is ``done`` on a
         clean run or ``error`` on a nonzero Claude Code exit.
 
+        Workspace derivation moved to the sandbox side in Phase 1 of
+        the repo-provisioning rollout. The bot now passes
+        ``thread_id`` (always) and optionally ``repo_url`` / ``ref``;
+        the sandbox's ``provision_workspace`` Modal function (or its
+        no-repo fast path) materializes the workspace and the run
+        proceeds against it.
+
         Uses Modal's ``.remote_gen.aio`` so the stream is consumed
         directly on the event loop — no ``run_in_executor`` dance.
         """
         logger.info(
             "dispatch.start",
             session_id=session_id,
+            thread_id=thread_id,
+            repo_url=repo_url,
+            ref=ref,
             resume=resume,
             attachment_count=len(attachments) if attachments else 0,
         )
@@ -67,8 +79,10 @@ class SandboxDispatcher:
         event_count = 0
         async for event in self._fn.remote_gen.aio(
             session_id=session_id,
-            workspace_path=workspace_path,
             prompt=prompt,
+            thread_id=thread_id,
+            repo_url=repo_url,
+            ref=ref,
             resume=resume,
             attachments=attachments or [],
             message_id=message_id,

--- a/apps/delulu_discord/src/delulu_discord/handlers.py
+++ b/apps/delulu_discord/src/delulu_discord/handlers.py
@@ -11,6 +11,7 @@ from delulu_discord.streaming import INITIAL_PLACEHOLDER, LiveStatus
 
 if TYPE_CHECKING:
     from delulu_discord.dispatcher import SandboxDispatcher
+    from delulu_discord.repo_config import RepoConfig
     from delulu_discord.session_manager import SessionManager
     from delulu_discord.settings import Settings
 
@@ -25,17 +26,35 @@ class MessageHandler:
         settings: Settings,
         session_manager: SessionManager,
         dispatcher: SandboxDispatcher,
+        repo_config: RepoConfig,
     ) -> None:
         self.settings = settings
         self.sessions = session_manager
         self.dispatcher = dispatcher
+        self.repo_config = repo_config
 
     async def handle_channel_message(self, message: discord.Message, prompt: str) -> None:
-        """New @-mention in a channel → create thread, dispatch task."""
+        """New @-mention in a channel → create thread, dispatch task.
+
+        Looks up the channel's repo binding via ``RepoConfig.get()``
+        — if the channel is bound, the new session is created with
+        the (repo_url, ref) tuple, which the sandbox's
+        ``provision_workspace`` will use to clone+worktree the repo.
+        If unbound (the current default for every channel until
+        Phase 3 ships ``/setrepo``), the session has ``repo_url=None``
+        and the sandbox falls through to the empty-workspace
+        general-Q&A path.
+        """
         thread_name = prompt[:50].strip() or "Claude Code task"
         thread = await message.create_thread(name=thread_name)
 
-        session = self.sessions.create_session(thread.id)
+        binding = self.repo_config.get(message.channel.id)
+        if binding is None:
+            repo_url, ref = None, self.settings.default_git_ref
+        else:
+            repo_url, ref = binding
+
+        session = self.sessions.create_session(thread.id, repo_url=repo_url, ref=ref)
         attachments = await _download_attachments(message)
 
         logger.info(
@@ -44,6 +63,8 @@ class MessageHandler:
             session_id=session.session_id,
             prompt_preview=prompt[:80],
             attachment_count=len(attachments),
+            repo_url=repo_url,
+            ref=ref,
         )
 
         await self._dispatch_and_respond(
@@ -114,8 +135,10 @@ class MessageHandler:
         try:
             async for event in self.dispatcher.run_task(
                 session_id=session.session_id,
-                workspace_path=session.workspace_path,
+                thread_id=session.thread_id,
                 prompt=prompt,
+                repo_url=session.repo_url,
+                ref=session.ref,
                 resume=resume,
                 attachments=attachments,
                 message_id=message_id,

--- a/apps/delulu_discord/src/delulu_discord/main.py
+++ b/apps/delulu_discord/src/delulu_discord/main.py
@@ -11,6 +11,7 @@ import structlog
 
 from delulu_discord.dispatcher import SandboxDispatcher
 from delulu_discord.handlers import MessageHandler
+from delulu_discord.repo_config import RepoConfig
 from delulu_discord.session_manager import SessionManager
 from delulu_discord.settings import Settings
 
@@ -34,10 +35,16 @@ def create_bot(settings: Settings) -> discord.Client:
     # ── Wire up components ───────────────────────────────────
     session_manager = SessionManager(ttl_seconds=settings.session_ttl_seconds)
     dispatcher = SandboxDispatcher(settings=settings)
+    # RepoConfig instantiates a modal.Dict at startup. Empty until
+    # the /setrepo command (Phase 3) lets users add bindings; until
+    # then `repo_config.get(channel_id)` always returns None and
+    # every dispatch falls through to the no-repo general-Q&A path.
+    repo_config = RepoConfig()
     handler = MessageHandler(
         settings=settings,
         session_manager=session_manager,
         dispatcher=dispatcher,
+        repo_config=repo_config,
     )
 
     # ── Event handlers ───────────────────────────────────────

--- a/apps/delulu_discord/src/delulu_discord/repo_allowlist.py
+++ b/apps/delulu_discord/src/delulu_discord/repo_allowlist.py
@@ -1,0 +1,90 @@
+"""Per-server allowlist of repos the bot is permitted to provision.
+
+Companion to ``repo_config.py``. Where ``RepoConfig`` stores
+"this channel is bound to this repo", ``RepoAllowlist`` stores
+"this Discord server is allowed to bind these repos at all" — the
+access-control layer that prevents random users from pointing the
+bot at huge or unrelated repositories. See the "Access control and
+threat model" section of ``prd/repo-provisioning.md`` for the full
+threat model.
+
+Keyed by Discord ``guild_id``; values are lists of ``owner/repo``
+short forms (e.g. ``["alice/api-service", "alice-org/shared-lib"]``).
+
+Phase 2 ships the data store; Phase 4 wires it into the
+``/admin_addrepo`` / ``/admin_removerepo`` / ``/admin_listrepos``
+slash commands gated on Discord's ``MANAGE_GUILD`` permission.
+Until then this class exists but has no callers in the bot's
+runtime path.
+
+**Concurrency note.** ``add()`` / ``remove()`` are read-modify-write
+on the underlying ``modal.Dict`` value, which has a TOCTOU window
+if two admins concurrently mutate the same guild's allowlist.
+For v1 admin commands are rare (one human at a time), so this is
+acceptable. If contention ever becomes real, the right fix is to
+move the mutation into a Modal function with ``max_containers=1``
+keyed on the guild ID — same pattern as ``provision_workspace``
+in the sandbox app.
+"""
+
+from __future__ import annotations
+
+import modal
+import structlog
+
+logger = structlog.get_logger()
+
+DICT_NAME = "discord-orchestrator-allowlist"
+
+
+class RepoAllowlist:
+    """Modal-Dict-backed per-guild repo allowlist."""
+
+    def __init__(self) -> None:
+        self._dict = modal.Dict.from_name(DICT_NAME, create_if_missing=True)
+
+    def get(self, guild_id: int) -> list[str]:
+        """Return the allowlist for a guild (empty list if unset).
+
+        Used by ``/setrepo`` autocomplete + validation, and by
+        ``/admin_listrepos`` to show the current state.
+        """
+        return list(self._dict.get(guild_id) or [])
+
+    def add(self, guild_id: int, owner_repo: str) -> None:
+        """Add an entry to a guild's allowlist. Idempotent."""
+        current = self.get(guild_id)
+        if owner_repo in current:
+            return
+        current.append(owner_repo)
+        self._dict[guild_id] = current
+        logger.info(
+            "repo_allowlist.add",
+            guild_id=guild_id,
+            owner_repo=owner_repo,
+        )
+
+    def remove(self, guild_id: int, owner_repo: str) -> None:
+        """Remove an entry from a guild's allowlist. No-op if not present.
+
+        Note: does NOT retroactively unbind channels that were
+        previously bound to the removed repo. Existing bindings in
+        ``RepoConfig`` survive until explicitly ``/unsetrepo``'d. The
+        next ``/setrepo`` in those channels will fail the allowlist
+        check, so the recovery path is "rebind to an allowed repo or
+        unbind manually."
+        """
+        current = self.get(guild_id)
+        if owner_repo not in current:
+            return
+        current.remove(owner_repo)
+        self._dict[guild_id] = current
+        logger.info(
+            "repo_allowlist.remove",
+            guild_id=guild_id,
+            owner_repo=owner_repo,
+        )
+
+    def contains(self, guild_id: int, owner_repo: str) -> bool:
+        """True iff ``owner_repo`` is on ``guild_id``'s allowlist."""
+        return owner_repo in self.get(guild_id)

--- a/apps/delulu_discord/src/delulu_discord/repo_config.py
+++ b/apps/delulu_discord/src/delulu_discord/repo_config.py
@@ -1,0 +1,71 @@
+"""Persistent channel→repo binding store, backed by a Modal Dict.
+
+This is the data layer for the /setrepo and /unsetrepo slash
+commands (wired up in Phase 3). The store maps Discord channel IDs
+to a (repo_url, ref) tuple — when the bot dispatches a new thread
+in a bound channel, it looks up the binding here and threads
+``repo_url`` / ``ref`` through to the sandbox's
+``provision_workspace``.
+
+Lives on the bot side, not the sandbox side. The bot has Modal
+client auth via ``/root/.modal.toml``, so it can talk to
+``modal.Dict`` directly without going through a deployed function.
+
+The Dict is created lazily on first use via ``create_if_missing=True``
+— no out-of-band setup required when standing up a fresh deployment.
+Phase 2 wires this class into MessageHandler but doesn't yet expose
+any way to add bindings; that comes in Phase 3 with the /setrepo
+slash command. Until then, ``get()`` always returns ``None`` and
+the dispatch path falls through to the no-repo (general Q&A)
+behavior — exactly the same shape as today's bot.
+"""
+
+from __future__ import annotations
+
+import modal
+import structlog
+
+logger = structlog.get_logger()
+
+DICT_NAME = "discord-orchestrator-repo-config"
+
+
+class RepoConfig:
+    """Modal-Dict-backed channel→(repo_url, ref) binding store."""
+
+    def __init__(self) -> None:
+        self._dict = modal.Dict.from_name(DICT_NAME, create_if_missing=True)
+
+    def get(self, channel_id: int) -> tuple[str, str] | None:
+        """Return ``(repo_url, ref)`` for a channel, or ``None`` if unbound.
+
+        Used by the message handler at thread-creation time. Returning
+        ``None`` is the "general Q&A mode" sentinel — the dispatch
+        proceeds with an empty workspace and no git operations.
+        """
+        raw = self._dict.get(channel_id)
+        if raw is None:
+            return None
+        # Stored as a small dict so the schema is self-describing in
+        # Modal's UI and survives field additions.
+        return raw["repo_url"], raw["ref"]
+
+    def set(self, channel_id: int, repo_url: str, ref: str = "HEAD") -> None:
+        """Bind a channel to ``(repo_url, ref)``. Overwrites any existing binding."""
+        self._dict[channel_id] = {"repo_url": repo_url, "ref": ref}
+        logger.info(
+            "repo_config.set",
+            channel_id=channel_id,
+            repo_url=repo_url,
+            ref=ref,
+        )
+
+    def unset(self, channel_id: int) -> None:
+        """Remove a channel's binding. No-op if not present."""
+        # `pop` on modal.Dict raises KeyError if missing; swallow it
+        # so callers don't have to special-case the no-binding path.
+        try:
+            self._dict.pop(channel_id)
+            logger.info("repo_config.unset", channel_id=channel_id)
+        except KeyError:
+            pass

--- a/apps/delulu_discord/src/delulu_discord/session_manager.py
+++ b/apps/delulu_discord/src/delulu_discord/session_manager.py
@@ -13,13 +13,41 @@ logger = structlog.get_logger()
 
 @dataclass
 class Session:
-    """Represents a Claude Code session bound to a Discord thread."""
+    """Represents a Claude Code session bound to a Discord thread.
+
+    The workspace path is **derived**, not stored — it's always
+    ``/vol/workspaces/<thread_id>``, set by the sandbox's
+    ``provision_workspace`` Modal function. Storing it as a property
+    here keeps the bot side from accidentally drifting from the
+    sandbox's authoritative path layout.
+
+    ``repo_url`` and ``ref`` capture the channel's repo binding at
+    session creation time. Once a thread is started, its binding is
+    grandfathered for the lifetime of the session — even if someone
+    later ``/setrepo``s the channel to a different repo, in-flight
+    threads keep their original repo. This matches the PRD's
+    "thread binding is captured at thread creation" decision.
+    """
 
     session_id: str
     thread_id: int
-    workspace_path: str
+    repo_url: str | None = None
+    ref: str = "HEAD"
     created_at: float = field(default_factory=time.time)
     last_active_at: float = field(default_factory=time.time)
+
+    @property
+    def workspace_path(self) -> str:
+        """Deterministic per-thread workspace path on the Modal volume.
+
+        Mirrors ``WORKSPACES_ROOT`` in
+        ``delulu_sandbox_modal.repo_provisioner``. Kept as a property
+        rather than a stored field so the bot can never drift from
+        the sandbox's source of truth — the sandbox's
+        ``provision_workspace`` is what actually creates the
+        directory; this property is just for logging and dispatch.
+        """
+        return f"/vol/workspaces/{self.thread_id}"
 
     def is_expired(self, ttl_seconds: int) -> bool:
         return (time.time() - self.last_active_at) > ttl_seconds
@@ -32,28 +60,43 @@ class SessionManager:
     """Thread-to-session mapping with TTL-based expiry.
 
     Thread IDs are the primary key. When a thread's session expires,
-    we keep the workspace but start a fresh Claude Code session.
+    we keep the workspace but start a fresh Claude Code session — the
+    workspace_path is deterministic per thread_id so this Just Works
+    without any explicit reuse logic.
     """
 
     def __init__(self, ttl_seconds: int = 3600) -> None:
         self._sessions: dict[int, Session] = {}
         self._ttl = ttl_seconds
 
-    def create_session(self, thread_id: int, repo_url: str | None = None) -> Session:
-        """Create a new session for a thread.
+    def create_session(
+        self,
+        thread_id: int,
+        *,
+        repo_url: str | None = None,
+        ref: str = "HEAD",
+    ) -> Session:
+        """Create a new session for a thread, optionally bound to a repo.
 
-        The workspace path is deterministic per thread_id — so across bot
-        restarts and TTL expiries the same Discord thread always maps to the
-        same directory on the Modal volume, and Claude Code's `--continue`
-        (which keys its history off cwd) finds the prior conversation.
+        ``repo_url`` and ``ref`` come from the channel's binding (via
+        ``RepoConfig``) at thread-creation time — see
+        ``MessageHandler.handle_channel_message``. Stored on the
+        Session so subsequent thread replies inherit the binding
+        without re-querying ``RepoConfig`` and without re-checking
+        the allowlist (bindings are grandfathered).
+
+        The workspace path is deterministic per thread_id — same
+        directory on the Modal volume across bot restarts and TTL
+        expiries — so Claude Code's ``--continue`` (which keys its
+        history off cwd) finds the prior conversation.
         """
         session_id = uuid.uuid4().hex[:12]
-        workspace_path = f"/vol/workspaces/{thread_id}"
 
         session = Session(
             session_id=session_id,
             thread_id=thread_id,
-            workspace_path=workspace_path,
+            repo_url=repo_url,
+            ref=ref,
         )
         self._sessions[thread_id] = session
 
@@ -61,7 +104,9 @@ class SessionManager:
             "session.created",
             session_id=session_id,
             thread_id=thread_id,
-            workspace_path=workspace_path,
+            workspace_path=session.workspace_path,
+            repo_url=repo_url,
+            ref=ref,
         )
         return session
 
@@ -84,24 +129,39 @@ class SessionManager:
         return session
 
     def get_or_create(self, thread_id: int) -> tuple[Session, bool]:
-        """Get existing session or create new one. Returns (session, is_new)."""
+        """Get existing session or create new one. Returns (session, is_new).
+
+        On TTL expiry the prior session's ``repo_url`` / ``ref`` are
+        carried over to the fresh session — same Discord thread, same
+        repo binding, fresh Claude Code session. This is what makes
+        a long-running thread keep working after the bot's session
+        TTL fires; the user shouldn't have to re-bind a repo just
+        because their thread went idle for an hour.
+        """
         existing = self.get_session(thread_id)
         if existing is not None:
             return existing, False
 
-        # Check if there was a previous (expired) session — reuse workspace path
+        # Check if there was a previous (expired) session and inherit
+        # its repo binding so the fresh session keeps targeting the
+        # same repo.
         old = self._sessions.get(thread_id)
-        session = self.create_session(thread_id)
-
         if old is not None:
-            # Reuse the workspace directory from the expired session
-            session.workspace_path = old.workspace_path
+            session = self.create_session(
+                thread_id,
+                repo_url=old.repo_url,
+                ref=old.ref,
+            )
             logger.info(
                 "session.reused_workspace",
                 old_session=old.session_id,
                 new_session=session.session_id,
                 workspace_path=session.workspace_path,
+                repo_url=session.repo_url,
+                ref=session.ref,
             )
+        else:
+            session = self.create_session(thread_id)
 
         return session, True
 

--- a/apps/delulu_discord/src/delulu_discord/settings.py
+++ b/apps/delulu_discord/src/delulu_discord/settings.py
@@ -22,3 +22,12 @@ class Settings(BaseSettings):
     # ── Session behavior ─────────────────────────────────────
     session_ttl_seconds: int = 3600  # 1 hour before session resets
     max_output_length: int = 1900  # Discord limit minus some margin
+
+    # ── Repo provisioning ────────────────────────────────────
+    # The bare-cache root on the Modal Volume. Mirrors the constant
+    # in delulu_sandbox_modal.repo_provisioner; the bot doesn't read
+    # the volume directly but the value is exposed here so admin
+    # commands and observability code have one source of truth.
+    repo_cache_root: str = "/vol/repo-cache"
+    # Default git ref for /setrepo when the user doesn't pass one.
+    default_git_ref: str = "HEAD"

--- a/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/app.py
+++ b/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/app.py
@@ -301,16 +301,29 @@ def run_claude_code(
                 "run_claude_code requires either `workspace_path` (legacy) or "
                 "`thread_id` (for provision_workspace.remote). Got neither."
             )
-        workspace_path = provision_workspace.remote(
-            thread_id=thread_id,
-            repo_url=repo_url,
-            ref=ref,
-        )
-        # The provisioning function committed the volume. Reload so
-        # this container sees the newly-created worktree on its
-        # mounted view of /vol — without this, the cwd we're about
-        # to use doesn't exist from this container's perspective.
-        volume.reload()
+        if repo_url is None:
+            # **Fast path: no-repo / general-Q&A mode.** When there's
+            # no repo to provision, there's nothing for the
+            # max_containers=1 serialization to coordinate — every
+            # call would just `os.makedirs` an empty directory in
+            # its own private container. Skip the Modal function hop
+            # entirely and create the workspace inline. Saves the
+            # ~1–2s per-dispatch orchestration overhead for the
+            # common no-binding case (which is every channel until
+            # Phase 3 ships /setrepo).
+            workspace_path = f"/vol/workspaces/{thread_id}"
+        else:
+            workspace_path = provision_workspace.remote(
+                thread_id=thread_id,
+                repo_url=repo_url,
+                ref=ref,
+            )
+            # The provisioning function committed the volume. Reload
+            # so this container sees the newly-created worktree on
+            # its mounted view of /vol — without this, the cwd we're
+            # about to use doesn't exist from this container's
+            # perspective.
+            volume.reload()
 
     os.makedirs(workspace_path, exist_ok=True)
 


### PR DESCRIPTION
## Summary
Phase 2 of \`prd/repo-provisioning.md\`. Wires the repo binding data flow through the bot pipeline. **No user-facing UX changes** — every channel still falls through to the no-repo general-Q&A path until Phase 3 ships \`/setrepo\`.

This is one logical PR that touches both apps:
- **Bot side**: data classes, signature changes, and \`RepoConfig\` injection into \`MessageHandler\`
- **Sandbox side**: one targeted optimization (\`run_claude_code\` no-repo fast path) so Phase 2 doesn't regress empty-workspace dispatches by 1–2s

Backwards-compatible: Phase 1 already shipped a sandbox that accepts both the legacy \`workspace_path\` kwarg and the new \`thread_id\` shape. Phase 2 switches the bot to the new shape; the legacy kwarg in \`run_claude_code\` is intentionally kept so a bot rebuild and a Modal redeploy don't have to ship atomically.

## What's in the diff

### Bot side (8 files)

- **\`repo_config.py\`** (new, 71 lines) — \`modal.Dict\`-backed channel→\`(repo_url, ref)\` binding store. Data layer for \`/setrepo\` and \`/unsetrepo\` in Phase 3. \`get()\` always returns \`None\` until Phase 3 lets users add bindings.
- **\`repo_allowlist.py\`** (new, 90 lines) — \`modal.Dict\`-backed per-server allowlist. Data layer for the admin slash commands in Phase 4. Not yet instantiated in \`main.py\`. Documents the read-modify-write TOCTOU caveat: fine for rare admin commands, would need \`max_containers=1\` keyed by guild_id if contention ever becomes real.
- **\`session_manager.py\`** — \`Session\` gains \`repo_url\` / \`ref\` fields. \`workspace_path\` becomes a derived property (\`/vol/workspaces/<thread_id>\`) instead of a stored field, so the bot can never drift from the sandbox's authoritative path layout. \`get_or_create\` TTL-recovery now carries the prior session's repo binding to the fresh session, so long-running threads keep working past TTL expiry.
- **\`dispatcher.py\`** — \`run_task\` signature swaps \`workspace_path\` for \`thread_id\` + \`repo_url\` + \`ref\`. Pass-through to \`run_claude_code\`.
- **\`handlers.py\`** — \`MessageHandler\` gains a \`repo_config: RepoConfig\` constructor arg. \`handle_channel_message\` looks up the binding via \`RepoConfig.get(channel.id)\` and threads it through to \`create_session\`. \`_dispatch_and_respond\` passes the new dispatch args.
- **\`main.py\`** — instantiates \`RepoConfig()\` at bot startup and injects into \`MessageHandler\`.
- **\`settings.py\`** — adds \`repo_cache_root\` and \`default_git_ref\`. Mirrors constants in \`repo_provisioner\` so admin commands and observability have one source of truth.

### Sandbox side (1 file)

- **\`app.py\`** — adds a no-repo **fast path** to \`run_claude_code\`. When \`thread_id\` is set but \`repo_url is None\`, skip the \`provision_workspace.remote()\` Modal hop entirely and compute the workspace path inline. Saves the ~1–2s per-dispatch orchestration overhead for the no-binding case (which is every channel until Phase 3 ships \`/setrepo\`). Without this, Phase 2 would regress every empty-workspace dispatch by 1–2s.

## Test plan
- [x] \`uv run --frozen --extra dev ruff format --check . && ruff check . && pytest\` on \`delulu_sandbox_modal\` → **39 passed**, ruff clean
- [x] \`uv run --frozen --extra dev ruff format --check . && ruff check . && pytest\` on \`delulu_discord\` → **22 passed**, ruff clean
- [ ] Merge this
- [ ] Smoke test on the live bot: existing \`@delulu\` invocations should continue to work with no observable difference (the data-flow rewire should be invisible)
- [ ] Phase 3 wires \`/setrepo\` + \`/unsetrepo\` + \`LiveStatus\` repo subtitle
- [ ] Phase 4 wires admin allowlist commands + \`/commit\`

## Notes for review
- **Why is the fast path in the sandbox side?** Because it's a sandbox-level optimization: skipping the Modal function hop has to happen in \`run_claude_code\` itself, before the \`.remote()\` call. Doing it on the bot side would require the bot to know about Modal function topology, which is the sandbox's concern.
- **Why keep the legacy \`workspace_path\` kwarg in \`run_claude_code\`?** Deployment ordering. A bot Docker rebuild and a Modal redeploy don't ship atomically. If the sandbox deploys first with only the new signature, a still-running old bot calling with \`workspace_path\` would crash. Keeping the legacy path is a small price for safe rolling deploys; a cleanup PR after the next deploy cycle can remove it.
- **Why no new tests?** The Phase 2 changes are mostly data-flow plumbing through existing code paths, and the new modules (\`repo_config\`, \`repo_allowlist\`) are thin \`modal.Dict\` wrappers that need real Modal credentials to exercise meaningfully. The slash command handlers in Phase 3/4 are where unit tests start to pay for themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)