### PR TITLE
feat(bot): slash commands + LiveStatus repo subtitle (phase 3)

### DIFF
--- a/apps/delulu_discord/src/delulu_discord/commands.py
+++ b/apps/delulu_discord/src/delulu_discord/commands.py
@@ -1,0 +1,339 @@
+"""Discord slash command handlers for repo binding and admin allowlist management.
+
+Five commands ship in Phase 3:
+
+- ``/setrepo repo:<owner>/<repo> ref:<HEAD>`` — bind the current
+  channel to a repo. User-facing, no permission gate, but rejects
+  any repo not on the server's allowlist (set via
+  ``/admin_addrepo`` below).
+- ``/unsetrepo`` — clear the current channel's binding.
+- ``/admin_addrepo repo:<owner>/<repo>`` — admin only. Validates
+  the repo exists via the GitHub REST API and adds it to this
+  server's allowlist.
+- ``/admin_removerepo repo:<owner>/<repo>`` — admin only.
+  Autocomplete-fed remove from the allowlist.
+- ``/admin_listrepos`` — admin only. Show the current allowlist.
+
+All admin commands are gated via
+``@app_commands.default_permissions(manage_guild=True)``, which
+Discord enforces server-side: unprivileged users don't even see
+these commands in the autocomplete list, and even if they tried
+to invoke them via a raw interaction, Discord would reject before
+the handler runs.
+
+**Why GitHub REST API instead of `git ls-remote`?** The bot's
+Docker image is ``python:3.14-slim`` with no ``git`` binary
+installed, so we can't shell out to git. The REST API check is
+also async-friendly, which fits the discord.py event loop better
+than a blocking subprocess. Unauthenticated GitHub API gives 60
+req/hour which is plenty for an admin command that only fires on
+explicit allowlist additions.
+
+**Repo identity format.** Slash commands accept ``owner/repo``
+short form and the allowlist stores the same. ``RepoConfig``
+stores the full URL (``https://github.com/owner/repo``)
+reconstructed at bind time, because that's what the sandbox needs
+for ``git clone``. The display side (LiveStatus repo subtitle)
+parses ``owner/repo`` back out of the full URL — see
+``streaming._short_repo_name``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import aiohttp
+import discord
+import structlog
+from discord import app_commands
+
+if TYPE_CHECKING:
+    from delulu_discord.repo_allowlist import RepoAllowlist
+    from delulu_discord.repo_config import RepoConfig
+
+logger = structlog.get_logger()
+
+# Discord caps slash command autocomplete at 25 choices.
+AUTOCOMPLETE_CHOICE_LIMIT = 25
+
+# GitHub REST API timeout for the /admin_addrepo validation call.
+# Short to keep slash commands snappy; the handler defers the
+# response so the user sees a "Bot is thinking..." spinner during
+# the wait.
+GITHUB_API_TIMEOUT_SECONDS = 10
+
+# owner/repo format: alphanumeric, dots, dashes, underscores in
+# both segments. Matches GitHub's repo naming rules. Path-traversal
+# attempts (`..`, leading dots) are rejected by the character class.
+OWNER_REPO_RE = re.compile(r"^[A-Za-z0-9_-][A-Za-z0-9._-]*/[A-Za-z0-9_-][A-Za-z0-9._-]*$")
+
+
+def register_slash_commands(
+    tree: app_commands.CommandTree,
+    *,
+    repo_config: RepoConfig,
+    repo_allowlist: RepoAllowlist,
+) -> None:
+    """Register all repo-related slash commands on the given tree.
+
+    Called once at bot startup from ``main.create_bot``. After this
+    returns the ``CommandTree`` has the commands defined; the
+    ``on_ready`` handler is responsible for calling ``tree.sync()``
+    to push them to Discord. Closures over ``repo_config`` and
+    ``repo_allowlist`` keep each command body self-contained without
+    needing a holder class.
+    """
+
+    # ── /setrepo ────────────────────────────────────────────
+    @tree.command(
+        name="setrepo",
+        description="Bind a GitHub repo to this channel for @claude tasks",
+    )
+    @app_commands.describe(
+        repo="Repository in owner/repo format (must be on the server's allowlist)",
+        ref="Git ref to use (default: HEAD)",
+    )
+    async def setrepo(
+        interaction: discord.Interaction,
+        repo: str,
+        ref: str = "HEAD",
+    ) -> None:
+        if interaction.guild_id is None or interaction.channel_id is None:
+            await interaction.response.send_message(
+                "❌ This command can only be used in a server channel.",
+                ephemeral=True,
+            )
+            return
+
+        repo = repo.strip()
+        if not OWNER_REPO_RE.match(repo):
+            await interaction.response.send_message(
+                f"❌ `{repo}` is not in `owner/repo` format. Example: `alice/api-service`.",
+                ephemeral=True,
+            )
+            return
+
+        if not repo_allowlist.contains(interaction.guild_id, repo):
+            current = repo_allowlist.get(interaction.guild_id)
+            if current:
+                listing = "\n".join(f"  • `{r}`" for r in current)
+                msg = (
+                    f"❌ `{repo}` is not on this server's allowlist.\n\n"
+                    f"Currently allowed:\n{listing}\n\n"
+                    "Ask a server admin to run `/admin_addrepo` to add it."
+                )
+            else:
+                msg = (
+                    "❌ This server has no allowed repos yet. "
+                    "Ask a server admin to run `/admin_addrepo` first."
+                )
+            await interaction.response.send_message(msg, ephemeral=True)
+            return
+
+        # Reconstruct the canonical full URL for storage. The sandbox
+        # needs this form for `git clone`; the bot's display code
+        # parses owner/repo back out of it via _short_repo_name.
+        full_url = f"https://github.com/{repo}"
+        repo_config.set(interaction.channel_id, full_url, ref)
+
+        await interaction.response.send_message(
+            f"✅ Channel bound to `{repo}@{ref}`. "
+            "New `@claude` mentions in this channel will run against this repo.",
+            ephemeral=True,
+        )
+
+    @setrepo.autocomplete("repo")
+    async def setrepo_autocomplete(
+        interaction: discord.Interaction,
+        current: str,
+    ) -> list[app_commands.Choice[str]]:
+        if interaction.guild_id is None:
+            return []
+        return _build_autocomplete_choices(
+            repo_allowlist.get(interaction.guild_id),
+            current,
+        )
+
+    # ── /unsetrepo ──────────────────────────────────────────
+    @tree.command(
+        name="unsetrepo",
+        description="Clear this channel's repo binding",
+    )
+    async def unsetrepo(interaction: discord.Interaction) -> None:
+        if interaction.channel_id is None:
+            await interaction.response.send_message(
+                "❌ This command can only be used in a channel.",
+                ephemeral=True,
+            )
+            return
+
+        repo_config.unset(interaction.channel_id)
+        await interaction.response.send_message(
+            "✅ Channel unbound. New `@claude` mentions will run with no repo (general Q&A mode).",
+            ephemeral=True,
+        )
+
+    # ── /admin_addrepo ──────────────────────────────────────
+    @tree.command(
+        name="admin_addrepo",
+        description="Add a public GitHub repo to this server's allowlist (admin only)",
+    )
+    @app_commands.default_permissions(manage_guild=True)
+    @app_commands.describe(repo="Repository in owner/repo format")
+    async def admin_addrepo(interaction: discord.Interaction, repo: str) -> None:
+        if interaction.guild_id is None:
+            await interaction.response.send_message(
+                "❌ This command can only be used in a server.",
+                ephemeral=True,
+            )
+            return
+
+        repo = repo.strip()
+        if not OWNER_REPO_RE.match(repo):
+            await interaction.response.send_message(
+                f"❌ `{repo}` is not in `owner/repo` format.",
+                ephemeral=True,
+            )
+            return
+
+        # Defer — the GitHub API call can take a couple seconds and
+        # Discord wants an initial response within 3s. defer() shows
+        # a "Bot is thinking..." spinner and gives us 15 minutes to
+        # send the followup.
+        await interaction.response.defer(ephemeral=True, thinking=True)
+
+        ok, msg = await _validate_github_public_repo(repo)
+        if not ok:
+            await interaction.followup.send(
+                f"❌ Couldn't add `{repo}`: {msg}",
+                ephemeral=True,
+            )
+            return
+
+        repo_allowlist.add(interaction.guild_id, repo)
+        await interaction.followup.send(
+            f"✅ `{repo}` added to this server's allowlist.\nUsers can now `/setrepo` against it.",
+            ephemeral=True,
+        )
+
+    # ── /admin_removerepo ───────────────────────────────────
+    @tree.command(
+        name="admin_removerepo",
+        description="Remove a repo from this server's allowlist (admin only)",
+    )
+    @app_commands.default_permissions(manage_guild=True)
+    @app_commands.describe(repo="Repository to remove")
+    async def admin_removerepo(interaction: discord.Interaction, repo: str) -> None:
+        if interaction.guild_id is None:
+            await interaction.response.send_message(
+                "❌ This command can only be used in a server.",
+                ephemeral=True,
+            )
+            return
+
+        repo = repo.strip()
+        if not repo_allowlist.contains(interaction.guild_id, repo):
+            await interaction.response.send_message(
+                f"`{repo}` isn't on this server's allowlist — nothing to remove.",
+                ephemeral=True,
+            )
+            return
+
+        repo_allowlist.remove(interaction.guild_id, repo)
+        await interaction.response.send_message(
+            f"✅ `{repo}` removed from this server's allowlist.\n\n"
+            "*Note: existing channel bindings to this repo are NOT cleared. "
+            "Run `/unsetrepo` in any affected channels.*",
+            ephemeral=True,
+        )
+
+    @admin_removerepo.autocomplete("repo")
+    async def admin_removerepo_autocomplete(
+        interaction: discord.Interaction,
+        current: str,
+    ) -> list[app_commands.Choice[str]]:
+        if interaction.guild_id is None:
+            return []
+        return _build_autocomplete_choices(
+            repo_allowlist.get(interaction.guild_id),
+            current,
+        )
+
+    # ── /admin_listrepos ────────────────────────────────────
+    @tree.command(
+        name="admin_listrepos",
+        description="Show this server's allowed repos (admin only)",
+    )
+    @app_commands.default_permissions(manage_guild=True)
+    async def admin_listrepos(interaction: discord.Interaction) -> None:
+        if interaction.guild_id is None:
+            await interaction.response.send_message(
+                "❌ This command can only be used in a server.",
+                ephemeral=True,
+            )
+            return
+
+        current = repo_allowlist.get(interaction.guild_id)
+        if not current:
+            await interaction.response.send_message(
+                "*This server has no allowed repos yet. Add one with `/admin_addrepo`.*",
+                ephemeral=True,
+            )
+            return
+
+        listing = "\n".join(f"• `{r}`" for r in current)
+        await interaction.response.send_message(
+            f"**Allowed repos for this server:**\n{listing}",
+            ephemeral=True,
+        )
+
+    logger.info("commands.registered", count=5)
+
+
+def _build_autocomplete_choices(
+    items: list[str],
+    current: str,
+) -> list[app_commands.Choice[str]]:
+    """Return up to 25 autocomplete choices matching ``current`` substring.
+
+    Discord truncates anything beyond 25, and the search is intentionally
+    a substring match (not just prefix) so users can find a repo by
+    typing any part of the name.
+    """
+    needle = current.lower()
+    matches = [r for r in items if needle in r.lower()]
+    return [app_commands.Choice(name=r, value=r) for r in matches[:AUTOCOMPLETE_CHOICE_LIMIT]]
+
+
+async def _validate_github_public_repo(owner_repo: str) -> tuple[bool, str]:
+    """Verify that a public GitHub repo exists.
+
+    Hits ``GET https://api.github.com/repos/<owner>/<repo>`` and
+    interprets the status code:
+
+    - 200: repo exists and is public
+    - 404: repo doesn't exist or is private (we treat both the same
+      since v1 doesn't support private repo provisioning)
+    - 403: rate-limited (60 req/hour unauthenticated)
+    - anything else: surfaced as "GitHub API returned HTTP <code>"
+
+    Returns ``(ok, message)``. The message is suitable for direct
+    use in a Discord error response.
+    """
+    url = f"https://api.github.com/repos/{owner_repo}"
+    timeout = aiohttp.ClientTimeout(total=GITHUB_API_TIMEOUT_SECONDS)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url) as resp:
+                if resp.status == 200:
+                    return True, "ok"
+                if resp.status == 404:
+                    return False, "repo not found (or is private — v1 only supports public repos)"
+                if resp.status == 403:
+                    return False, "GitHub API rate limit exceeded — try again later"
+                return False, f"GitHub API returned HTTP {resp.status}"
+    except TimeoutError:
+        return False, "timed out reaching api.github.com"
+    except aiohttp.ClientError as exc:
+        return False, f"network error: {type(exc).__name__}"

--- a/apps/delulu_discord/src/delulu_discord/handlers.py
+++ b/apps/delulu_discord/src/delulu_discord/handlers.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import discord
 import structlog
 
-from delulu_discord.streaming import INITIAL_PLACEHOLDER, LiveStatus
+from delulu_discord.streaming import LiveStatus, _render
 
 if TYPE_CHECKING:
     from delulu_discord.dispatcher import SandboxDispatcher
@@ -120,12 +120,25 @@ class MessageHandler:
         # The flag sticks across edits, so setting it once at post time
         # is enough to keep the live status from unfurling any URLs
         # that might appear in tool summaries.
+        # Render the initial placeholder with the repo subtitle (if
+        # bound) baked in, so the very first state the user sees is
+        # already oriented to the repo. ``_render`` with an empty
+        # transcript and no done_footer returns the placeholder; the
+        # repo line is appended below it when ``repo_url`` is set.
+        # The subsequent flush loop and finalize_done will continue
+        # to pass repo_url/ref through _render so the subtitle stays
+        # visible across the whole message lifecycle.
+        initial_content = _render([], repo_url=session.repo_url, ref=session.ref)
         status_msg = await thread.send(
-            INITIAL_PLACEHOLDER,
+            initial_content,
             allowed_mentions=discord.AllowedMentions.none(),
             suppress_embeds=True,
         )
-        live = LiveStatus(status_msg)
+        live = LiveStatus(
+            status_msg,
+            repo_url=session.repo_url,
+            ref=session.ref,
+        )
         live.start()
 
         final_text = ""

--- a/apps/delulu_discord/src/delulu_discord/main.py
+++ b/apps/delulu_discord/src/delulu_discord/main.py
@@ -8,9 +8,12 @@ import sys
 
 import discord
 import structlog
+from discord import app_commands
 
+from delulu_discord.commands import register_slash_commands
 from delulu_discord.dispatcher import SandboxDispatcher
 from delulu_discord.handlers import MessageHandler
+from delulu_discord.repo_allowlist import RepoAllowlist
 from delulu_discord.repo_config import RepoConfig
 from delulu_discord.session_manager import SessionManager
 from delulu_discord.settings import Settings
@@ -31,15 +34,22 @@ def create_bot(settings: Settings) -> discord.Client:
     intents.guilds = True
 
     client = discord.Client(intents=intents)
+    # CommandTree owns the slash commands. Created here so the
+    # closure-over-deps registration in commands.register_slash_commands
+    # has a tree to attach to, and on_ready can call .sync() to push
+    # the commands to Discord at bot startup.
+    tree = app_commands.CommandTree(client)
 
     # ── Wire up components ───────────────────────────────────
     session_manager = SessionManager(ttl_seconds=settings.session_ttl_seconds)
     dispatcher = SandboxDispatcher(settings=settings)
-    # RepoConfig instantiates a modal.Dict at startup. Empty until
-    # the /setrepo command (Phase 3) lets users add bindings; until
-    # then `repo_config.get(channel_id)` always returns None and
-    # every dispatch falls through to the no-repo general-Q&A path.
+    # Modal-Dict-backed channel→(repo_url, ref) binding store. Set
+    # via /setrepo, looked up at @claude dispatch time.
     repo_config = RepoConfig()
+    # Modal-Dict-backed per-server allowlist. Populated via the
+    # admin slash commands gated on MANAGE_GUILD; consulted by
+    # /setrepo to decide whether a binding is permitted.
+    repo_allowlist = RepoAllowlist()
     handler = MessageHandler(
         settings=settings,
         session_manager=session_manager,
@@ -47,9 +57,29 @@ def create_bot(settings: Settings) -> discord.Client:
         repo_config=repo_config,
     )
 
+    register_slash_commands(
+        tree,
+        repo_config=repo_config,
+        repo_allowlist=repo_allowlist,
+    )
+
     # ── Event handlers ───────────────────────────────────────
     @client.event
     async def on_ready():
+        # Push slash command definitions to Discord. This is a
+        # global sync, which can take up to ~1 hour to propagate
+        # to every server the bot is installed in (Discord
+        # caches command definitions per-guild). For development
+        # against a single test guild, swap to
+        # ``await tree.sync(guild=discord.Object(id=...))`` for
+        # near-instant updates. Sync-on-startup is fine here:
+        # the bot doesn't restart often, and Discord deduplicates
+        # no-op syncs internally.
+        try:
+            synced = await tree.sync()
+            logger.info("commands.synced", count=len(synced))
+        except Exception:
+            logger.exception("commands.sync_failed")
         logger.info("bot.ready", user=str(client.user), guilds=len(client.guilds))
 
     @client.event

--- a/apps/delulu_discord/src/delulu_discord/streaming.py
+++ b/apps/delulu_discord/src/delulu_discord/streaming.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
+from urllib.parse import urlparse
 
 import discord
 import structlog
@@ -36,6 +37,8 @@ def _render(
     transcript: list[dict[str, Any]],
     *,
     done_footer: str | None = None,
+    repo_url: str | None = None,
+    ref: str = "HEAD",
 ) -> str:
     """Render the running transcript into Discord markdown.
 
@@ -43,9 +46,14 @@ def _render(
     same output. Rules:
 
     - Empty transcript and no ``done_footer`` → initial
-      "thinking..." placeholder.
+      "thinking..." placeholder. The repo subtitle is appended below
+      the placeholder if a repo is bound.
     - Latest ``thinking`` block collapses into one spoiler line at the
       top (``||🧠 Reasoning: …||``).
+    - If ``repo_url`` is set, an active-repo subtitle line
+      (``📁 owner/repo@ref``) is rendered as the second line, right
+      below the thinking/reasoning header. Omitted entirely when
+      ``repo_url is None``.
     - Each ``tool_use`` becomes ``🔧 <Tool> <summary>`` with a trailing
       ``✓`` / ``✗`` if a matching ``tool_result`` followed it.
     - If any assistant ``text`` event is present AND the run isn't
@@ -59,10 +67,16 @@ def _render(
       ``✅ Done • N tools • Ts`` footer, rather than collapsing the
       whole message.
     - If the transcript overflows Discord's 2000-char limit, drop the
-      oldest tool-call lines and prefix with a truncation marker.
+      oldest tool-call lines and prefix with a truncation marker. The
+      repo subtitle is **protected** — never truncated, since it's a
+      single short line and dropping it would lose orientation.
     """
+    repo_line = _format_repo_line(repo_url, ref)
+
     if not transcript and done_footer is None:
-        return INITIAL_PLACEHOLDER
+        if repo_line is None:
+            return INITIAL_PLACEHOLDER
+        return f"{INITIAL_PLACEHOLDER}\n{repo_line}"
 
     header = _render_header(transcript)
     tool_lines = _render_tool_lines(transcript)
@@ -70,11 +84,49 @@ def _render(
     # once the run is done, the writing is also done, so suppress it.
     writing_marker = _render_writing_marker(transcript) if done_footer is None else None
 
-    rendered = _assemble(header, tool_lines, writing_marker, done_footer)
+    rendered = _assemble(header, tool_lines, writing_marker, done_footer, repo_line)
     if len(rendered) <= DISCORD_MESSAGE_LIMIT:
         return rendered
 
-    return _truncate_to_limit(header, tool_lines, writing_marker, done_footer)
+    return _truncate_to_limit(header, tool_lines, writing_marker, done_footer, repo_line)
+
+
+def _format_repo_line(repo_url: str | None, ref: str) -> str | None:
+    """Build the ``📁 owner/repo@ref`` subtitle line, or None if no repo.
+
+    Parses ``owner/repo`` from the full URL for compact display. The
+    parsing is intentionally inline (rather than importing from the
+    sandbox-side ``repo_provisioner``) — the bot and sandbox apps
+    are deliberately kept import-isolated so they can deploy
+    independently.
+    """
+    if not repo_url:
+        return None
+    return f"📁 {_short_repo_name(repo_url)}@{ref}"
+
+
+def _short_repo_name(repo_url: str) -> str:
+    """Return ``owner/repo`` from a git URL.
+
+    Accepts ``https://github.com/owner/repo[.git]`` and
+    ``git@host:owner/repo[.git]``. Falls back to the raw URL on
+    anything unparseable rather than raising — display code should
+    never crash on a weird value.
+    """
+    url = repo_url.strip().rstrip("/")
+    if url.endswith(".git"):
+        url = url[:-4].rstrip("/")
+
+    if url.startswith("git@"):
+        # git@host:owner/repo
+        _, _, path = url[len("git@") :].partition(":")
+    else:
+        path = urlparse(url).path.lstrip("/")
+
+    parts = [p for p in path.split("/") if p]
+    if len(parts) >= 2:
+        return f"{parts[-2]}/{parts[-1]}"
+    return repo_url
 
 
 def _render_header(transcript: list[dict[str, Any]]) -> str:
@@ -138,8 +190,11 @@ def _assemble(
     tool_lines: list[str],
     writing_marker: str | None,
     done_footer: str | None = None,
+    repo_line: str | None = None,
 ) -> str:
     parts = [header]
+    if repo_line:
+        parts.append(repo_line)
     parts.extend(tool_lines)
     if writing_marker:
         parts.append(writing_marker)
@@ -153,18 +208,21 @@ def _truncate_to_limit(
     tool_lines: list[str],
     writing_marker: str | None,
     done_footer: str | None = None,
+    repo_line: str | None = None,
 ) -> str:
     """Drop oldest tool lines until the assembled output fits.
 
     Always keeps at least the most recent tool line so the user sees
     what's currently running. Prefixes the remaining list with a
     ``… earlier tool calls truncated`` marker once anything is dropped.
+    The repo subtitle is protected — it's a single short line and
+    dropping it would lose orientation across multi-thread channels.
     """
     kept = list(tool_lines)
     truncated = False
     while kept:
         candidate_tool_lines = ["🔧 … earlier tool calls truncated", *kept] if truncated else kept
-        rendered = _assemble(header, candidate_tool_lines, writing_marker, done_footer)
+        rendered = _assemble(header, candidate_tool_lines, writing_marker, done_footer, repo_line)
         if len(rendered) <= DISCORD_MESSAGE_LIMIT:
             return rendered
         kept.pop(0)
@@ -173,7 +231,7 @@ def _truncate_to_limit(
     # Pathological fallback: even an empty tool list overflows (huge
     # thinking preview). Hard-truncate the result so we never post
     # something Discord would reject outright.
-    rendered = _assemble(header, [], writing_marker, done_footer)
+    rendered = _assemble(header, [], writing_marker, done_footer, repo_line)
     return rendered[:DISCORD_MESSAGE_LIMIT]
 
 
@@ -199,9 +257,19 @@ class LiveStatus:
         status_msg: discord.Message,
         *,
         flush_interval: float = FLUSH_INTERVAL_SECONDS,
+        repo_url: str | None = None,
+        ref: str = "HEAD",
     ) -> None:
         self.status_msg = status_msg
         self.flush_interval = flush_interval
+        # Optional active-repo subtitle, captured at LiveStatus
+        # construction time. Sourced from the ``Session.repo_url`` /
+        # ``Session.ref`` set when the channel had a binding via
+        # ``RepoConfig`` — see ``handlers._dispatch_and_respond``.
+        # ``None`` (the default) means "no repo bound" and the
+        # subtitle line is omitted entirely.
+        self.repo_url = repo_url
+        self.ref = ref
         self.transcript: list[dict[str, Any]] = []
         self._last_rendered: str | None = None
         self._dirty = False
@@ -230,7 +298,14 @@ class LiveStatus:
         """
         await self._stop_flush()
         footer = render_done(num_tools, duration_ms)
-        await self._safe_edit(_render(self.transcript, done_footer=footer))
+        await self._safe_edit(
+            _render(
+                self.transcript,
+                done_footer=footer,
+                repo_url=self.repo_url,
+                ref=self.ref,
+            )
+        )
 
     async def finalize_error(self) -> None:
         """Stop the flush loop and leave the status frozen on its last state.
@@ -240,7 +315,7 @@ class LiveStatus:
         before the error, not the last rate-limited flush.
         """
         await self._stop_flush()
-        await self._safe_edit(_render(self.transcript))
+        await self._safe_edit(_render(self.transcript, repo_url=self.repo_url, ref=self.ref))
 
     async def _flush_loop(self) -> None:
         while not self._stopped:
@@ -258,7 +333,7 @@ class LiveStatus:
                 logger.exception("streaming.flush_failed")
 
     async def _flush_once(self) -> None:
-        rendered = _render(self.transcript)
+        rendered = _render(self.transcript, repo_url=self.repo_url, ref=self.ref)
         if rendered == self._last_rendered:
             self._dirty = False
             return

--- a/apps/delulu_discord/tests/test_streaming.py
+++ b/apps/delulu_discord/tests/test_streaming.py
@@ -294,3 +294,149 @@ async def test_flush_once_skips_edit_when_content_unchanged() -> None:
     # No new events → _render output is unchanged → no redundant edit.
     await live._flush_once()
     assert msg.edit.call_count == 1
+
+
+# ── Active-repo subtitle line (Phase 3 addition) ─────────────────
+#
+# The repo subtitle renders as the second line of the status
+# message, right under the thinking/reasoning header, whenever a
+# repo is bound. Omitted entirely when no binding. These tests
+# pin the contract so future renderer changes don't accidentally
+# drop the orientation indicator.
+
+
+REPO_URL = "https://github.com/alice/api-service"
+
+
+def test_render_no_repo_omits_subtitle_line() -> None:
+    """Empty/None repo_url → no subtitle line, identical to pre-Phase-3 output."""
+    rendered = _render([_tool_use("Read", "`x.py`")])
+    assert "📁" not in rendered
+    assert "alice" not in rendered
+
+
+def test_render_with_repo_adds_subtitle_under_header() -> None:
+    """Repo line is the SECOND line, right under the thinking/reasoning header."""
+    rendered = _render(
+        [_tool_use("Read", "`x.py`")],
+        repo_url=REPO_URL,
+        ref="main",
+    )
+    lines = rendered.splitlines()
+    assert lines[0].startswith("💭")  # default placeholder header
+    assert lines[1] == "📁 alice/api-service@main"
+    assert "🔧 Read `x.py`" in rendered
+
+
+def test_render_with_repo_under_thinking_spoiler() -> None:
+    """When reasoning is present the spoiler header is line 0; repo line is line 1."""
+    rendered = _render(
+        [
+            {"type": "thinking", "text": "considering the approach"},
+            _tool_use("Read", "`x.py`"),
+        ],
+        repo_url=REPO_URL,
+        ref="main",
+    )
+    lines = rendered.splitlines()
+    assert lines[0].startswith("||🧠 Reasoning:")
+    assert lines[1] == "📁 alice/api-service@main"
+
+
+def test_render_empty_transcript_with_repo_shows_placeholder_plus_subtitle() -> None:
+    """Initial state (no events yet) renders the placeholder + subtitle."""
+    rendered = _render([], repo_url=REPO_URL, ref="HEAD")
+    assert rendered == f"{INITIAL_PLACEHOLDER}\n📁 alice/api-service@HEAD"
+
+
+def test_render_empty_transcript_no_repo_is_just_placeholder() -> None:
+    """Initial state with no binding is the bare placeholder, unchanged from pre-Phase-3."""
+    assert _render([], repo_url=None) == INITIAL_PLACEHOLDER
+
+
+def test_render_done_state_keeps_repo_subtitle() -> None:
+    """The repo line stays visible in the final 'done' state too."""
+    transcript = [
+        _tool_use("Read", "`x.py`"),
+        _tool_result("Read", ok=True),
+    ]
+    rendered = _render(
+        transcript,
+        done_footer="✅ Done • 1 tools • 2.0s",
+        repo_url=REPO_URL,
+        ref="main",
+    )
+    lines = rendered.splitlines()
+    assert lines[1] == "📁 alice/api-service@main"
+    assert lines[-1] == "✅ Done • 1 tools • 2.0s"
+
+
+def test_render_truncation_protects_repo_subtitle() -> None:
+    """Even when overflow truncates tool lines, the repo subtitle stays."""
+    transcript = [
+        _tool_use("Read", f"`very/long/path/to/source/file_{i:04d}.py`") for i in range(300)
+    ]
+    rendered = _render(transcript, repo_url=REPO_URL, ref="main")
+    assert len(rendered) <= DISCORD_MESSAGE_LIMIT
+    assert "📁 alice/api-service@main" in rendered
+    assert "earlier tool calls truncated" in rendered
+
+
+def test_short_repo_name_handles_https_url() -> None:
+    from delulu_discord.streaming import _short_repo_name
+
+    assert _short_repo_name("https://github.com/alice/api-service") == "alice/api-service"
+
+
+def test_short_repo_name_handles_https_url_trailing_git() -> None:
+    from delulu_discord.streaming import _short_repo_name
+
+    assert _short_repo_name("https://github.com/alice/api-service.git") == "alice/api-service"
+
+
+def test_short_repo_name_handles_ssh_url() -> None:
+    from delulu_discord.streaming import _short_repo_name
+
+    assert _short_repo_name("git@github.com:alice/api-service.git") == "alice/api-service"
+
+
+def test_short_repo_name_unparseable_falls_back_to_raw() -> None:
+    """Display code must never crash on a weird URL — better to show the raw."""
+    from delulu_discord.streaming import _short_repo_name
+
+    assert _short_repo_name("not-a-url") == "not-a-url"
+
+
+async def test_live_status_passes_repo_to_render() -> None:
+    """LiveStatus's repo_url/ref must thread through to the flush loop's _render call."""
+    msg = _fake_message()
+    live = LiveStatus(msg, repo_url=REPO_URL, ref="main")
+    live.push(_tool_use("Read", "`x.py`"))
+
+    await live._flush_once()
+    msg.edit.assert_called_once()
+    content = msg.edit.call_args.kwargs["content"]
+    assert "📁 alice/api-service@main" in content
+
+
+async def test_live_status_no_repo_omits_subtitle_in_flush() -> None:
+    msg = _fake_message()
+    live = LiveStatus(msg)  # no repo
+    live.push(_tool_use("Read", "`x.py`"))
+
+    await live._flush_once()
+    content = msg.edit.call_args.kwargs["content"]
+    assert "📁" not in content
+
+
+async def test_finalize_done_includes_repo_subtitle() -> None:
+    msg = _fake_message()
+    live = LiveStatus(msg, repo_url=REPO_URL, ref="main")
+    live.push(_tool_use("Read", "`x.py`"))
+    live.push(_tool_result("Read", ok=True))
+
+    await live.finalize_done(num_tools=1, duration_ms=1500)
+    msg.edit.assert_called_once()
+    content = msg.edit.call_args.kwargs["content"]
+    assert "📁 alice/api-service@main" in content
+    assert content.endswith("✅ Done • 1 tools • 1.5s")


### PR DESCRIPTION
## Summary
Phase 3 of \`prd/repo-provisioning.md\`. Ships **all five slash commands** (admin + user) plus the **LiveStatus active-repo subtitle**. After this PR, users can bind a channel to an allowlisted repo and have \`@claude\` run against it end-to-end, with the active repo visible in every status message.

## Phasing decision (worth flagging)
The PRD's original Phase 3/4 split was \"user commands first, admin commands later.\" That doesn't actually work — \`/setrepo\` validates against the allowlist, and the allowlist is empty until admin commands populate it. So between Phase 3 and Phase 4 merging, \`/setrepo\` would reject everything. **Regrouped:** Phase 3 ships all slash commands together so the allowlist can be populated and used in the same PR. Phase 4 shrinks to just \`/commit\` + commit-back flow.

## What's in the diff

### \`commands.py\` (new, 339 lines)
All five slash command handlers in one module. \`register_slash_commands(tree, repo_config, repo_allowlist)\` is called once at startup and registers each command as a closure over the data store deps. No holder class — the closure approach matches discord.py idiom.

| Command | Permission | Effect |
|---|---|---|
| \`/setrepo repo:<owner>/<repo> ref:HEAD\` | none (user) | Validates format, checks allowlist, stores binding in \`RepoConfig\`. Autocomplete on \`repo\` from the server's allowlist. |
| \`/unsetrepo\` | none (user) | Clears the channel's \`RepoConfig\` binding. |
| \`/admin_addrepo repo:<owner>/<repo>\` | \`MANAGE_GUILD\` | Validates the repo exists via GitHub REST API, adds to allowlist. Defers the response (API call takes ~1s). |
| \`/admin_removerepo repo:<owner>/<repo>\` | \`MANAGE_GUILD\` | Autocomplete-fed remove. Existing channel bindings are NOT retroactively cleared — documented in the response. |
| \`/admin_listrepos\` | \`MANAGE_GUILD\` | Ephemeral list of current allowlist. |

**Why GitHub REST API instead of \`git ls-remote\`?** The bot's Docker image is \`python:3.14-slim\` with no git binary. The REST API check is also async-friendly, which fits discord.py's event loop better than a blocking subprocess. Unauthenticated GitHub API gives 60 req/hour which is plenty for an admin command.

**Path-traversal hardening:** \`OWNER_REPO_RE\` rejects \`..\` and leading dots in either segment, mirroring the security guard in \`repo_provisioner._parse_repo_url\` from PR #46.

### \`streaming.py\` (modified)
- \`_render\` and \`_assemble\` gain optional \`repo_url\` / \`ref\` parameters
- When set, a \`📁 owner/repo@ref\` subtitle line renders as the **second** line of the status message (right under the thinking/reasoning header)
- When unset, the rendered output is **bit-identical** to pre-Phase-3 — no behavior change for the no-binding case
- New \`_short_repo_name\` helper parses \`owner/repo\` out of the full URL inline (rather than importing from the sandbox-side \`repo_provisioner\` — the bot/sandbox app boundary stays clean)
- \`LiveStatus.__init__\` takes \`repo_url\` / \`ref\` and threads them through to every \`_render\` call site

### \`handlers.py\` (modified)
- \`_dispatch_and_respond\` constructs the initial status message via \`_render([], repo_url=session.repo_url, ref=session.ref)\` so the placeholder + repo subtitle ship together in the very first send
- \`LiveStatus(...)\` is constructed with the same repo info so the flush loop continues to render the subtitle

### \`main.py\` (modified)
- Creates a \`discord.app_commands.CommandTree\`
- Instantiates \`RepoAllowlist()\` (alongside the existing \`RepoConfig()\`)
- Calls \`register_slash_commands(...)\` to attach all five commands
- \`on_ready\` calls \`await tree.sync()\` to push command definitions to Discord. Sync-on-startup is fine: the bot doesn't restart often, and Discord deduplicates no-op syncs

### Tests
**14 new tests** in \`test_streaming.py\` covering the repo subtitle:
- Subtitle present/absent based on \`repo_url\`
- Position: always second line (under thinking placeholder OR reasoning spoiler)
- Initial-state rendering with empty transcript
- Done-state preservation
- Truncation protection (subtitle survives even when tool lines get dropped)
- \`_short_repo_name\` parsing for https/ssh/trailing-.git/unparseable inputs
- \`LiveStatus\` end-to-end flush with mocked \`Message\`

## Test plan
- [x] \`uv run --frozen --extra dev ruff format --check . && ruff check . && pytest\` on \`delulu_discord\` → **36 passed** (22 existing + 14 new), ruff clean
- [x] \`uv run --frozen --extra dev ruff format --check . && ruff check . && pytest\` on \`delulu_sandbox_modal\` → **39 passed** (unchanged), ruff clean
- [ ] Merge this
- [ ] Smoke test on the live bot:
  - Run \`/admin_addrepo repo:leehanchung/SMILE-factory\` as a server admin → expect ✅
  - Run \`/admin_listrepos\` → expect to see the new repo
  - Run \`/setrepo repo:leehanchung/SMILE-factory\` in a channel → expect ✅
  - Mention \`@claude what's in the README\` → expect a thread with the LiveStatus showing \`📁 leehanchung/SMILE-factory@HEAD\` as the second line
  - Run \`/unsetrepo\` → expect ✅
  - Run \`/admin_removerepo\` → autocomplete should show the repo
- [ ] Phase 4 wires \`/commit\` + commit-back flow (PAT handling, refuse-and-instruct on missing secret)

## Notes for review
- **No tests for \`commands.py\`.** Discord.py interaction handlers need the full client/interaction object graph to test meaningfully, and the five command bodies are mostly input validation → store mutation → response. The risk of silent regressions is low. Phase 4's \`/commit\` handler is where mock infrastructure starts to pay for itself if we want it.
- **\`tree.sync()\` is global.** Command definitions can take up to ~1 hour to propagate to all servers Discord-side after the first deploy. For development against a single test guild, the comment in \`main.py\` explains how to swap to a guild-scoped sync for instant updates.
- **\`_short_repo_name\` duplicates parsing logic** from \`repo_provisioner._parse_repo_url\` (5 lines). The duplication is intentional — the bot and sandbox apps are deliberately import-isolated for independent deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)