### PR TITLE
feat: /commit + commit-back flow with refuse-and-instruct (phase 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,49 @@ invocations. The secret only seeds the volume on first run — after that
 the volume copy is the source of truth. If auth ever breaks, delete
 `claude-home/` from the volume and re-create the secret.
 
+#### `github-pat` Modal secret (required for deploy, optional for /commit)
+
+The sandbox app's `commit_workspace` Modal function references a
+`github-pat` secret to enable `/commit` push-back to GitHub. The
+secret **must exist** for `modal deploy` to succeed (Modal's
+`Secret.from_name` doesn't have an optionality flag). If you don't
+have a real PAT yet, create the secret with a placeholder value:
+
+```bash
+uv run modal secret create github-pat GITHUB_TOKEN=placeholder
+```
+
+This is enough for the app to deploy. `/commit` will refuse with a
+clear "configure your PAT" message until you replace the placeholder
+with a real token.
+
+When you're ready to enable `/commit`, generate a fine-grained PAT
+at https://github.com/settings/tokens?type=beta with **Contents:
+Read and write** scoped to the specific repos you want the bot to
+push to (matching your allowlist). Then update the secret:
+
+```bash
+uv run modal secret create github-pat GITHUB_TOKEN=ghp_xxxxxx --force
+```
+
+Optional: override the git author identity used for bot commits
+(defaults to `Claude Code <claude@bot.local>`):
+
+```bash
+uv run modal secret create github-pat \
+    GITHUB_TOKEN=ghp_xxxxxx \
+    GIT_AUTHOR_NAME="Han Lee" \
+    GIT_AUTHOR_EMAIL="han@example.com" \
+    --force
+```
+
+Commits made by `/commit` will be authored under that name/email and
+pushed under the PAT owner's GitHub identity. The two don't have to
+match — the author field is cosmetic, the PAT is what GitHub
+authenticates against. For a single-user setup where you want
+commits to look like they came from you, set both to your own
+GitHub name/email and use a PAT scoped to your account.
+
 Deploy the sandbox app (from the repo root):
 
 ```bash

--- a/apps/delulu_discord/src/delulu_discord/commands.py
+++ b/apps/delulu_discord/src/delulu_discord/commands.py
@@ -49,8 +49,10 @@ import structlog
 from discord import app_commands
 
 if TYPE_CHECKING:
+    from delulu_discord.dispatcher import SandboxDispatcher
     from delulu_discord.repo_allowlist import RepoAllowlist
     from delulu_discord.repo_config import RepoConfig
+    from delulu_discord.session_manager import SessionManager
 
 logger = structlog.get_logger()
 
@@ -74,15 +76,23 @@ def register_slash_commands(
     *,
     repo_config: RepoConfig,
     repo_allowlist: RepoAllowlist,
+    session_manager: SessionManager,
+    dispatcher: SandboxDispatcher,
 ) -> None:
     """Register all repo-related slash commands on the given tree.
 
     Called once at bot startup from ``main.create_bot``. After this
     returns the ``CommandTree`` has the commands defined; the
     ``on_ready`` handler is responsible for calling ``tree.sync()``
-    to push them to Discord. Closures over ``repo_config`` and
-    ``repo_allowlist`` keep each command body self-contained without
-    needing a holder class.
+    to push them to Discord. Closures over the data store deps
+    (``repo_config``, ``repo_allowlist``) and the bot-state deps
+    (``session_manager``, ``dispatcher``) keep each command body
+    self-contained without needing a holder class.
+
+    The ``session_manager`` and ``dispatcher`` deps are only used
+    by ``/commit``, which needs to look up the current thread's
+    session (for ``thread_id`` and the implicit repo binding) and
+    then dispatch the commit to the sandbox.
     """
 
     # ── /setrepo ────────────────────────────────────────────
@@ -288,7 +298,71 @@ def register_slash_commands(
             ephemeral=True,
         )
 
-    logger.info("commands.registered", count=5)
+    # ── /commit ─────────────────────────────────────────────
+    @tree.command(
+        name="commit",
+        description="Commit and push the current thread's workspace changes",
+    )
+    @app_commands.describe(message="Commit message")
+    async def commit(interaction: discord.Interaction, message: str) -> None:
+        # /commit only makes sense inside a Claude Code thread —
+        # the workspace it operates on is the per-thread one.
+        if not isinstance(interaction.channel, discord.Thread):
+            await interaction.response.send_message(
+                "❌ `/commit` must be run inside a Claude Code thread.",
+                ephemeral=True,
+            )
+            return
+
+        # The session must exist (so we know there's a workspace
+        # this thread is bound to) and must have a repo binding
+        # (so there's something meaningful to commit and push).
+        session = session_manager.get_session(interaction.channel.id)
+        if session is None:
+            await interaction.response.send_message(
+                "❌ No active session in this thread. Mention `@claude` first to create one.",
+                ephemeral=True,
+            )
+            return
+        if session.repo_url is None:
+            await interaction.response.send_message(
+                "❌ This thread has no repo binding — there's nothing to push to. "
+                "Use `/setrepo` in the parent channel to bind a repo, then start "
+                "a fresh `@claude` thread against it.",
+                ephemeral=True,
+            )
+            return
+
+        # Strip a trailing whitespace-only message defensively;
+        # discord.py allows zero-length strings through and git
+        # commit -m "" creates an empty-message commit which is
+        # confusing in git log.
+        message = message.strip()
+        if not message:
+            await interaction.response.send_message(
+                "❌ Commit message can't be empty.",
+                ephemeral=True,
+            )
+            return
+
+        # Defer — the sandbox roundtrip + git push can take 5–10s.
+        await interaction.response.defer(thinking=True)
+
+        try:
+            result = await dispatcher.commit_workspace(
+                thread_id=session.thread_id,
+                message=message,
+            )
+        except Exception as exc:
+            logger.exception("commit.dispatch_failed", thread_id=session.thread_id)
+            await interaction.followup.send(
+                f"⚠️ /commit dispatch failed: `{type(exc).__name__}: {exc}`"
+            )
+            return
+
+        await _render_commit_result(interaction, result)
+
+    logger.info("commands.registered", count=6)
 
 
 def _build_autocomplete_choices(
@@ -304,6 +378,82 @@ def _build_autocomplete_choices(
     needle = current.lower()
     matches = [r for r in items if needle in r.lower()]
     return [app_commands.Choice(name=r, value=r) for r in matches[:AUTOCOMPLETE_CHOICE_LIMIT]]
+
+
+async def _render_commit_result(
+    interaction: discord.Interaction,
+    result: dict,
+) -> None:
+    """Translate a sandbox-side commit_workspace result dict into a Discord followup.
+
+    The result shape is documented on
+    ``delulu_sandbox_modal.app.commit_workspace`` — five possible
+    ``status`` values, each with its own user-facing rendering.
+    Kept as a free function (not a method) because it has no
+    state of its own and lives next to the slash command for
+    readability.
+    """
+    status = result.get("status")
+
+    if status == "ok":
+        branch = result.get("branch", "claude/<thread>")
+        commit_sha = (result.get("commit_sha") or "")[:7]
+        pr_url = result.get("pr_compare_url")
+        body = f"✅ Committed `{commit_sha}` and pushed to branch `{branch}`."
+        if pr_url:
+            body += f"\n\nOpen a PR: {pr_url}"
+        await interaction.followup.send(body)
+        return
+
+    if status == "no_pat":
+        # Refuse-and-instruct, exactly as decided in the PRD.
+        await interaction.followup.send(
+            "❌ Can't commit — `github-pat` Modal secret missing or empty.\n\n"
+            "Run on your laptop:\n"
+            "```\nmodal secret create github-pat GITHUB_TOKEN=<your-pat>\n```\n"
+            "Then re-run `/commit`. Your workspace changes are still there."
+        )
+        return
+
+    if status == "no_changes":
+        await interaction.followup.send(
+            "ℹ️ Nothing to commit — the workspace has no pending changes."
+        )
+        return
+
+    if status == "no_workspace":
+        # Edge case: session exists but the per-thread workspace
+        # was never materialized (e.g. session created but no
+        # @claude dispatch followed). Tell the user to run a
+        # dispatch first.
+        error = result.get("error", "workspace not found")
+        await interaction.followup.send(
+            f"❌ No workspace for this thread — `{error}`.\n\n"
+            "Mention `@claude` in the thread first to materialize the workspace, "
+            "then re-run `/commit`."
+        )
+        return
+
+    if status == "push_failed":
+        # Local commit landed but push failed — most likely an
+        # invalid PAT (401) or insufficient scopes. The local
+        # commit is preserved on the workspace branch, so a
+        # subsequent /commit after rotating the PAT will catch
+        # everything up.
+        branch = result.get("branch", "claude/<thread>")
+        commit_sha = (result.get("commit_sha") or "")[:7]
+        error = result.get("error", "unknown push error")
+        await interaction.followup.send(
+            f"⚠️ Local commit `{commit_sha}` landed on `{branch}` but push failed.\n\n"
+            f"Git error: ```\n{error}\n```\n"
+            "Most likely the PAT is invalid or lacks `contents: write` on this repo. "
+            "Rotate the secret and re-run `/commit` — the queued commit will push too."
+        )
+        return
+
+    # Defensive: any unrecognized status. Better to surface "unexpected"
+    # than to silently succeed.
+    await interaction.followup.send(f"⚠️ Unexpected /commit result: `{result}`")
 
 
 async def _validate_github_public_repo(owner_repo: str) -> tuple[bool, str]:

--- a/apps/delulu_discord/src/delulu_discord/dispatcher.py
+++ b/apps/delulu_discord/src/delulu_discord/dispatcher.py
@@ -33,6 +33,14 @@ class SandboxDispatcher:
             settings.modal_app_name,
             "run_claude_code",
         )
+        # Separate handle for the /commit Modal function. Distinct
+        # from `_fn` because they have different signatures and
+        # different return shapes (run_claude_code is a generator
+        # of events; commit_workspace is a single dict).
+        self._commit_fn = modal.Function.from_name(
+            settings.modal_app_name,
+            "commit_workspace",
+        )
 
     async def run_task(
         self,
@@ -95,3 +103,34 @@ class SandboxDispatcher:
             session_id=session_id,
             event_count=event_count,
         )
+
+    async def commit_workspace(
+        self,
+        thread_id: int,
+        message: str,
+    ) -> dict[str, Any]:
+        """Dispatch /commit to the sandbox's `commit_workspace` Modal function.
+
+        Returns the function's result dict — see
+        ``delulu_sandbox_modal.app.commit_workspace`` for the
+        possible shapes (``status="ok" | "no_pat" | "no_workspace"
+        | "no_changes" | "push_failed"``).
+
+        The bot side is responsible for pre-checking that there's
+        an active session with a repo binding before calling this;
+        the sandbox doesn't have visibility into Discord-side
+        session state and would just return ``no_workspace`` for a
+        thread with no prior dispatch.
+        """
+        logger.info("commit.dispatch", thread_id=thread_id)
+        result: dict[str, Any] = await self._commit_fn.remote.aio(
+            thread_id=thread_id,
+            message=message,
+        )
+        logger.info(
+            "commit.complete",
+            thread_id=thread_id,
+            status=result.get("status"),
+            branch=result.get("branch"),
+        )
+        return result

--- a/apps/delulu_discord/src/delulu_discord/main.py
+++ b/apps/delulu_discord/src/delulu_discord/main.py
@@ -61,6 +61,8 @@ def create_bot(settings: Settings) -> discord.Client:
         tree,
         repo_config=repo_config,
         repo_allowlist=repo_allowlist,
+        session_manager=session_manager,
+        dispatcher=dispatcher,
     )
 
     # ── Event handlers ───────────────────────────────────────

--- a/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/app.py
+++ b/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/app.py
@@ -65,6 +65,29 @@ sandbox_image = (
 #     CLAUDE_CREDENTIALS_JSON="$(cat ~/.claude/.credentials.json)"
 claude_oauth_secret = modal.Secret.from_name("claude-oauth")
 
+# GitHub PAT for /commit push-back. The secret MUST exist for the
+# Modal app to deploy — Modal's `Secret.from_name` doesn't have an
+# optionality flag. To set up:
+#
+#     modal secret create github-pat GITHUB_TOKEN=ghp_xxxxxx
+#
+# The token can be a placeholder if /commit isn't going to be used
+# yet (e.g. `GITHUB_TOKEN=placeholder`); the runtime check in
+# `commit_workspace` will refuse-and-instruct when the value is
+# empty or doesn't look like a real PAT, leaving the workspace
+# untouched. Replace with a real fine-grained PAT scoped to the
+# repos in the allowlist when ready to enable push.
+#
+# Optional override env vars on the same secret control the git
+# author identity used for bot commits (defaults: "Claude Code"
+# / "claude@bot.local"):
+#
+#     modal secret create github-pat \
+#         GITHUB_TOKEN=ghp_xxxxxx \
+#         GIT_AUTHOR_NAME="Han Lee" \
+#         GIT_AUTHOR_EMAIL="han@example.com"
+github_pat_secret = modal.Secret.from_name("github-pat")
+
 
 # ── Stream-json helpers (module-level for testability) ───────
 # These parse Claude Code's ``--output-format stream-json`` lines into the
@@ -237,6 +260,107 @@ def provision_workspace(
     # can `volume.reload()` and see the fresh worktree + bare cache.
     volume.commit()
     return workspace_path
+
+
+# ── Commit-back Modal Function ───────────────────────────────
+# Dedicated function for /commit. Stages, commits, and pushes the
+# pending changes in a thread's workspace to a `claude/<thread_id>`
+# branch on the upstream repo.
+#
+# Same `provisioner_image` as `provision_workspace` — we only need
+# git, not Claude Code or nodejs. NOT decorated with
+# `max_containers=1`: each /commit invocation operates on a
+# distinct per-thread workspace, so there's no cross-call contention
+# and the Modal hop overhead is wasted. (Same-thread races are
+# avoided at the bot level — Discord serializes a single user's
+# slash command invocations per channel.)
+@app.function(
+    image=provisioner_image,
+    volumes={"/vol": volume},
+    secrets=[github_pat_secret],
+    timeout=120,
+)
+def commit_workspace(thread_id: int, message: str) -> dict[str, Any]:
+    """Stage, commit, and push pending changes in the thread's workspace.
+
+    Pre-flight check: refuses with ``status="no_pat"`` if the
+    ``GITHUB_TOKEN`` env var (from the github-pat secret) is empty
+    or missing. **No local commit is made in that case** — refuse-
+    and-instruct semantics, decided in
+    ``prd/repo-provisioning.md``'s "Commit-back flow" section.
+
+    Returns a dict (not a dataclass — Modal needs JSON-serializable
+    return values) with one of these shapes:
+
+        {"status": "ok", "branch": ..., "commit_sha": ...,
+         "pr_compare_url": ...}
+        {"status": "no_pat"}
+        {"status": "no_workspace", "error": "..."}
+        {"status": "no_changes"}
+        {"status": "push_failed", "branch": ..., "commit_sha": ...,
+         "error": "..."}
+    """
+    import os
+
+    # Lazy import — same rationale as in `provision_workspace`.
+    from delulu_sandbox_modal import repo_provisioner
+
+    # Pre-flight: refuse-and-instruct on missing PAT. Empty-string
+    # is the documented "secret exists but value is a placeholder"
+    # state — we treat it as missing.
+    github_token = (os.environ.get("GITHUB_TOKEN") or "").strip()
+    if not github_token or github_token == "placeholder":
+        logger.info(
+            "commit.refused_no_pat",
+            thread_id=thread_id,
+        )
+        return {"status": "no_pat"}
+
+    # Optional author identity overrides — see the secret comment
+    # at the top of this file.
+    author_name = os.environ.get("GIT_AUTHOR_NAME") or repo_provisioner.DEFAULT_GIT_AUTHOR_NAME
+    author_email = os.environ.get("GIT_AUTHOR_EMAIL") or repo_provisioner.DEFAULT_GIT_AUTHOR_EMAIL
+
+    # The workspace must be loaded from the most recently committed
+    # state of the volume — `provision_workspace` (or any concurrent
+    # /commit on this same thread, though that's prevented by
+    # bot-side serialization) might have changed it since this
+    # container started.
+    volume.reload()
+
+    result = repo_provisioner.commit_workspace_changes(
+        thread_id=thread_id,
+        message=message,
+        github_token=github_token,
+        author_name=author_name,
+        author_email=author_email,
+    )
+
+    logger.info(
+        "commit.result",
+        thread_id=thread_id,
+        status=result.status,
+        branch=result.branch,
+        commit_sha=result.commit_sha,
+        error=result.error,
+    )
+
+    # Commit the volume so the new commit on the local branch is
+    # persisted across container restarts (in case the user runs
+    # /commit again later from a fresh container).
+    volume.commit()
+
+    # Convert to a plain dict for Modal serialization. dataclass
+    # instances aren't auto-serializable across the Modal RPC
+    # boundary in all versions — using a dict is the safe lowest-
+    # common-denominator.
+    return {
+        "status": result.status,
+        "branch": result.branch,
+        "commit_sha": result.commit_sha,
+        "pr_compare_url": result.pr_compare_url,
+        "error": result.error,
+    }
 
 
 # ── Modal Function (runs inside the sandbox) ─────────────────

--- a/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/repo_provisioner.py
+++ b/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/repo_provisioner.py
@@ -324,3 +324,236 @@ def _run_git(args: list[str], *, check: bool = True) -> subprocess.CompletedProc
 
 def _elapsed_ms(start: float) -> int:
     return int((time.monotonic() - start) * 1000)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Commit-back: stage, commit, and push pending changes from a
+# per-thread workspace to a `claude/<thread_id>` branch on the
+# upstream repo.
+# ─────────────────────────────────────────────────────────────────
+#
+# Lives here (rather than in a separate module) because it's another
+# pure-git operation on the same workspaces that ``provision_workspace``
+# creates. Same import-isolation rules: no Modal decorators, no bot-
+# side imports. The Modal function wrapper that calls this lives in
+# ``app.py``.
+#
+# Refuse-and-instruct UX: callers are expected to check the
+# ``GITHUB_TOKEN`` env var BEFORE calling ``commit_workspace_changes``.
+# This module doesn't touch the env directly — it just takes the
+# token as a parameter so the function is testable without env
+# munging and the auth check stays at the boundary.
+
+# The branch name we always commit to. One branch per thread, so a
+# user can iterate on the same conceptual "task" across multiple
+# /commit calls and have them stack on the same branch — and the
+# remote PR (if they open one) shows the full history of the
+# thread's changes.
+COMMIT_BRANCH_PREFIX = "claude/"
+
+# The git author identity for bot-made commits. The ACTUAL pusher
+# (visible in GitHub's UI as "pushed by") is whoever owns the PAT
+# stored in the ``github-pat`` Modal secret; this name/email is
+# only what shows up in the commit object's Author/Committer
+# fields and in ``git log``. Defaults to a generic bot identity
+# so commits can be filtered out of git log easily; can be
+# overridden via env vars on the github-pat secret (see README).
+DEFAULT_GIT_AUTHOR_NAME = "Claude Code"
+DEFAULT_GIT_AUTHOR_EMAIL = "claude@bot.local"
+
+
+@dataclass
+class CommitResult:
+    """Result of a /commit operation.
+
+    The ``status`` field is the primary signal the bot side renders
+    into a Discord response; the other fields carry additional
+    context for the success and partial-failure cases.
+    """
+
+    status: str  # "ok" | "no_changes" | "no_workspace" | "push_failed"
+    branch: str | None = None
+    commit_sha: str | None = None
+    pr_compare_url: str | None = None
+    error: str | None = None
+
+
+def commit_workspace_changes(
+    thread_id: int,
+    message: str,
+    github_token: str,
+    *,
+    author_name: str = DEFAULT_GIT_AUTHOR_NAME,
+    author_email: str = DEFAULT_GIT_AUTHOR_EMAIL,
+) -> CommitResult:
+    """Stage, commit, and push pending changes in ``/vol/workspaces/<thread_id>``.
+
+    Idempotent in the no-op sense: if there are no changes, returns
+    ``status="no_changes"`` without making a commit. If there ARE
+    changes, makes one new commit on the ``claude/<thread_id>``
+    branch (creating the branch if missing) and pushes it to
+    ``origin``.
+
+    Auth: ``github_token`` is injected at push time via
+    ``-c http.extraheader``, never persisted to ``.git/config``.
+    The token is shell-escaped and the header is built with
+    ``x-access-token:<token>`` per GitHub's documented PAT-as-
+    HTTP-Basic format.
+
+    Caller must verify ``github_token`` is non-empty BEFORE calling
+    this function — refuse-and-instruct on missing PAT happens at
+    the boundary in ``app.py``, not here.
+    """
+    if not github_token:
+        # Defensive — caller should have refused already, but
+        # guarding here means a programming error never causes a
+        # broken push attempt with empty auth.
+        raise ValueError("github_token must not be empty")
+
+    workspace_path = _workspace_path(thread_id)
+    if not os.path.isdir(workspace_path):
+        return CommitResult(
+            status="no_workspace",
+            error=f"workspace {workspace_path} does not exist (no prior dispatch in this thread?)",
+        )
+
+    # Check for pending changes. ``git status --porcelain`` emits
+    # one line per dirty path (modified, added, deleted, untracked);
+    # empty output means a clean working tree.
+    status_result = _run_git(
+        ["-C", workspace_path, "status", "--porcelain"],
+    )
+    if not status_result.stdout.strip():
+        return CommitResult(status="no_changes")
+
+    branch = f"{COMMIT_BRANCH_PREFIX}{thread_id}"
+
+    # Check out the thread's branch. ``-B`` creates if missing OR
+    # resets to the current HEAD if existing — but we want to PRESERVE
+    # any prior commits on this branch from earlier /commit calls.
+    # So: try `git checkout` first; if that fails (branch doesn't
+    # exist), `git checkout -b` to create.
+    try:
+        _run_git(["-C", workspace_path, "checkout", branch])
+    except RuntimeError:
+        _run_git(["-C", workspace_path, "checkout", "-b", branch])
+
+    # Stage everything and commit with the bot's git identity.
+    # ``-c user.name=...`` is per-command, not persisted to config.
+    _run_git(["-C", workspace_path, "add", "-A"])
+    _run_git(
+        [
+            "-c",
+            f"user.name={author_name}",
+            "-c",
+            f"user.email={author_email}",
+            "-C",
+            workspace_path,
+            "commit",
+            "-m",
+            message,
+        ]
+    )
+
+    # Capture the new commit SHA for the response.
+    sha_result = _run_git(["-C", workspace_path, "rev-parse", "HEAD"])
+    commit_sha = sha_result.stdout.strip()
+
+    # Push via PAT-as-Basic-Auth header. This is how GitHub
+    # documents PAT auth over HTTPS. The header lives only on the
+    # one git invocation — never written to .git/config, never
+    # logged.
+    auth_header = _build_auth_header(github_token)
+    try:
+        _run_git(
+            [
+                "-c",
+                f"http.extraheader={auth_header}",
+                "-C",
+                workspace_path,
+                "push",
+                "origin",
+                branch,
+            ]
+        )
+    except RuntimeError as exc:
+        # Push failed — most commonly an invalid/expired PAT (401)
+        # or insufficient scopes. The local commit DID land on the
+        # workspace's branch, so the user can re-run /commit after
+        # rotating the PAT and the next push will catch up. Surface
+        # the git error to the bot so the user sees actionable
+        # detail instead of a generic "push failed."
+        return CommitResult(
+            status="push_failed",
+            branch=branch,
+            commit_sha=commit_sha,
+            error=str(exc),
+        )
+
+    pr_compare_url = _build_pr_compare_url(workspace_path, branch)
+
+    return CommitResult(
+        status="ok",
+        branch=branch,
+        commit_sha=commit_sha,
+        pr_compare_url=pr_compare_url,
+    )
+
+
+def _build_auth_header(github_token: str) -> str:
+    """Build the ``Authorization: Basic ...`` header for a GitHub PAT.
+
+    GitHub's documented format is ``x-access-token:<pat>``,
+    base64-encoded. Using ``x-access-token`` as the username is
+    the convention — anything works as the username, but
+    ``x-access-token`` is what GitHub's own docs and CLI use.
+    """
+    import base64
+
+    raw = f"x-access-token:{github_token}".encode()
+    encoded = base64.b64encode(raw).decode("ascii")
+    return f"Authorization: Basic {encoded}"
+
+
+def _build_pr_compare_url(workspace_path: str, branch: str) -> str | None:
+    """Build a ``github.com/<owner>/<repo>/compare/<base>...<branch>`` link.
+
+    Returns ``None`` if we can't extract the upstream URL or the
+    base ref — display code degrades to "branch pushed, open a PR
+    yourself" rather than crashing.
+    """
+    try:
+        # Get the origin URL.
+        origin_result = _run_git(
+            ["-C", workspace_path, "config", "--get", "remote.origin.url"],
+        )
+        origin_url = origin_result.stdout.strip()
+        if not origin_url:
+            return None
+
+        # Parse owner/repo out of the origin URL (same logic as the
+        # bot side's _short_repo_name in streaming.py, kept inline
+        # to avoid cross-app imports).
+        host, org, repo = _parse_repo_url(origin_url)
+        if host != "github.com":
+            # Compare URLs only documented for github.com; skip for
+            # other hosts.
+            return None
+
+        # Determine the base branch. The worktree was created from a
+        # specific ref; we want to compare against that. Read the
+        # ref from the .provision.json marker if present.
+        marker_path = os.path.join(workspace_path, PROVISION_MARKER_NAME)
+        base_ref = "main"
+        if os.path.isfile(marker_path):
+            try:
+                with open(marker_path) as f:
+                    base_ref = json.load(f).get("ref") or "main"
+            except (OSError, json.JSONDecodeError):
+                pass
+        if base_ref == "HEAD":
+            base_ref = "main"  # GitHub doesn't accept HEAD in compare URLs
+
+        return f"https://github.com/{org}/{repo}/compare/{base_ref}...{branch}?expand=1"
+    except (RuntimeError, ValueError):
+        return None

--- a/apps/delulu_sandbox_modal/tests/test_repo_provisioner.py
+++ b/apps/delulu_sandbox_modal/tests/test_repo_provisioner.py
@@ -122,3 +122,66 @@ class TestParseRepoUrl:
     def test_https_dotdot_in_repo_rejected(self):
         with pytest.raises(ValueError, match="unsafe repo"):
             _parse_repo_url("https://github.com/alice/../../etc")
+
+
+class TestBuildAuthHeader:
+    """The PAT-as-Basic-Auth header used for /commit pushes."""
+
+    def test_builds_basic_auth_header_with_x_access_token_user(self):
+        from delulu_sandbox_modal.repo_provisioner import _build_auth_header
+
+        header = _build_auth_header("ghp_abcdef123456")
+        # Basic auth = base64("x-access-token:ghp_abcdef123456")
+        assert header.startswith("Authorization: Basic ")
+        encoded = header[len("Authorization: Basic ") :]
+        import base64
+
+        decoded = base64.b64decode(encoded).decode()
+        assert decoded == "x-access-token:ghp_abcdef123456"
+
+    def test_handles_special_characters_in_token(self):
+        from delulu_sandbox_modal.repo_provisioner import _build_auth_header
+
+        # Fine-grained PAT format includes underscores and longer
+        # length; should encode fine.
+        token = "github_pat_11ABCDEFG_xyz123"
+        header = _build_auth_header(token)
+        import base64
+
+        decoded = base64.b64decode(header[len("Authorization: Basic ") :]).decode()
+        assert decoded == f"x-access-token:{token}"
+
+
+class TestCommitWorkspaceChanges:
+    """Pre-flight checks on commit_workspace_changes.
+
+    The full git path is integration-tested by hand against a real
+    Modal deploy — the unit test surface is limited to the
+    parameter validation branches that don't shell out to git.
+    """
+
+    def test_empty_token_raises_value_error(self):
+        from delulu_sandbox_modal.repo_provisioner import commit_workspace_changes
+
+        # Defensive check inside the function — caller is supposed
+        # to have refused on empty PAT before calling, but we
+        # belt-and-suspender it.
+        with pytest.raises(ValueError, match="github_token must not be empty"):
+            commit_workspace_changes(thread_id=42, message="test", github_token="")
+
+    def test_no_workspace_returns_status(self, tmp_path, monkeypatch):
+        """If the workspace dir doesn't exist, return no_workspace cleanly."""
+        from delulu_sandbox_modal import repo_provisioner
+
+        # Point WORKSPACES_ROOT at a tmpdir that has no thread
+        # subdirs — commit_workspace_changes should detect the
+        # missing dir and return a status, not raise.
+        monkeypatch.setattr(repo_provisioner, "WORKSPACES_ROOT", str(tmp_path))
+
+        result = repo_provisioner.commit_workspace_changes(
+            thread_id=999,
+            message="test",
+            github_token="ghp_dummy",
+        )
+        assert result.status == "no_workspace"
+        assert "999" in (result.error or "")


### PR DESCRIPTION
## Summary
**Final phase of \`prd/repo-provisioning.md\`.** Adds the \`/commit\` slash command and the sandbox-side \`commit_workspace\` Modal function. After this PR, users can stage, commit, and push their thread's pending changes to a \`claude/<thread_id>\` branch on the upstream repo.

**Refuse-and-instruct UX:** if the \`github-pat\` Modal secret is missing or empty, \`/commit\` refuses cleanly with the exact \`modal secret create\` command. The working tree is left untouched — no hidden local commit on the volume. This was the explicit decision from earlier — simpler than commit-locally-and-instruct, avoids the \"where did my work go?\" confusion of accumulating invisible state.

## What's in the diff

### Sandbox side
- **\`repo_provisioner.py\`**: new \`commit_workspace_changes()\` alongside the existing provisioning logic. Three branches: \`no_workspace\` / \`no_changes\` / full commit-and-push. Returns a \`CommitResult\` dataclass with status, branch, commit_sha, pr_compare_url, error fields. Helpers: \`_build_auth_header\` (PAT-as-Basic-Auth, GitHub's documented \`x-access-token:<pat>\` format) and \`_build_pr_compare_url\` (constructs a \`github.com/<owner>/<repo>/compare/<base>...<branch>?expand=1\` link).

- **\`app.py\`**: new \`commit_workspace\` Modal function with \`provisioner_image\` (no nodejs/claude-code) and \`secrets=[github_pat_secret]\`. Pre-flight check on \`GITHUB_TOKEN\` env var — refuses with \`{\"status\": \"no_pat\"}\` if empty or set to \`\"placeholder\"\`. **No \`max_containers=1\`** on this function — each /commit operates on a distinct per-thread workspace, no cross-call contention. Optional \`GIT_AUTHOR_NAME\` / \`GIT_AUTHOR_EMAIL\` overrides on the same secret.

### Bot side
- **\`dispatcher.py\`**: new \`commit_workspace(thread_id, message)\` method on \`SandboxDispatcher\`. Separate \`_commit_fn\` Modal Function handle.

- **\`commands.py\`**: new \`/commit message:<str>\` slash command. Validates thread context, looks up session, refuses without a repo binding, defers (sandbox roundtrip is 5–10s), dispatches via \`dispatcher.commit_workspace()\`. New \`_render_commit_result()\` helper translates each of the five status values into a user-facing followup. The \`no_pat\` branch carries the exact \`modal secret create\` instructions per refuse-and-instruct.

- **\`main.py\`**: passes \`session_manager\` and \`dispatcher\` to \`register_slash_commands\` (only \`/commit\` uses them).

### README
New \"github-pat Modal secret\" subsection under Modal setup. Documents the placeholder workflow for first deploy (since Modal's \`Secret.from_name\` doesn't have an optionality flag), the fine-grained PAT generation steps, and the \`GIT_AUTHOR_NAME\` / \`GIT_AUTHOR_EMAIL\` overrides. Explains the author-vs-pusher distinction.

### Tests
**4 new tests** in \`test_repo_provisioner.py\`:
- \`_build_auth_header\` produces the documented Basic-auth format
- Special characters in tokens (fine-grained PAT format) round-trip correctly
- \`commit_workspace_changes\` raises \`ValueError\` on empty \`github_token\` (defensive)
- \`commit_workspace_changes\` returns \`status=\"no_workspace\"\` when workspace dir doesn't exist (\`monkeypatch\` on \`WORKSPACES_ROOT\`)

## Test plan
- [x] \`uv run --frozen --extra dev ruff format --check . && ruff check . && pytest\` on \`delulu_sandbox_modal\` → **43 passed** (39 existing + 4 new), ruff clean
- [x] Same on \`delulu_discord\` → **36 passed** (unchanged), ruff clean
- [ ] **Before deploying:** create the github-pat secret with at least a placeholder value:
  \`\`\`
  modal secret create github-pat GITHUB_TOKEN=placeholder
  \`\`\`
  Without this, \`modal deploy\` will fail at \`Secret.from_name(\"github-pat\")\`.
- [ ] Merge this
- [ ] Smoke test on the live bot:
  1. Update the secret to a real fine-grained PAT scoped to the test repo
  2. \`/admin_addrepo repo:leehanchung/SMILE-factory\`
  3. In a channel: \`/setrepo repo:leehanchung/SMILE-factory\`
  4. \`@claude make a tiny change to the README\`
  5. In the resulting thread: \`/commit message:test commit\` → expect ✅ with PR compare URL
  6. Open the PR compare URL → confirm the bot's commit landed
  7. \`/commit message:second test\` with no changes → expect ℹ️ \"nothing to commit\"
  8. Force-update the secret to \`GITHUB_TOKEN=placeholder\`, redeploy
  9. \`/commit message:should refuse\` → expect ❌ refuse-and-instruct with the \`modal secret create\` instructions
  10. Workspace should be unchanged after the refuse — re-running with a real PAT should still find the changes

## What this completes
The repo-provisioning feature set is now done end-to-end:
- **Phase 1 (#46)**: sandbox-side provisioner + \`max_containers=1\` serialization
- **Phase 2 (#47)**: bot-side plumbing + no-repo fast path
- **Phase 3 (#48)**: all five slash commands + LiveStatus repo subtitle
- **Phase 4 (this)**: \`/commit\` + commit-back flow

The PRD's v1 scope ships with this PR. v2 work parked in the PRD: private repo support, \`/refresh\`, workspace GC, GitHub App for multi-user identity, per-repo concurrency via \`modal.Dict\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)