### PR TITLE
fix(sandbox): bundle delulu_sandbox_modal package into both images

### DIFF
--- a/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/app.py
+++ b/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/app.py
@@ -53,6 +53,14 @@ sandbox_image = (
         # Install Claude Code globally
         "npm install -g @anthropic-ai/claude-code",
     )
+    # Bundle the whole `delulu_sandbox_modal` package into the image so
+    # that runtime `from delulu_sandbox_modal import repo_provisioner`
+    # resolves inside the container. `modal deploy` only auto-mounts
+    # the entry file (app.py) at /root/app.py by default — sibling
+    # modules in the same package have to be added explicitly. Without
+    # this line, provision_workspace crashes at import time with
+    # `ModuleNotFoundError: No module named 'delulu_sandbox_modal'`.
+    .add_local_python_source("delulu_sandbox_modal")
 )
 
 # ── Secrets ──────────────────────────────────────────────────
@@ -205,6 +213,10 @@ provisioner_image = (
     modal.Image.debian_slim(python_version="3.14")
     .apt_install("git", "ca-certificates")
     .pip_install("structlog>=24.0")
+    # Same rationale as sandbox_image above — provision_workspace
+    # and commit_workspace both import `repo_provisioner` at
+    # runtime, so the package has to be in the container.
+    .add_local_python_source("delulu_sandbox_modal")
 )
 
 


### PR DESCRIPTION
## Summary
Fixes \`ModuleNotFoundError: No module named 'delulu_sandbox_modal'\` in \`provision_workspace\` (and \`commit_workspace\`) at runtime. The function crashed at Phase 1's \`from delulu_sandbox_modal import repo_provisioner\` line because the sibling module wasn't in the container.

## Root cause
\`modal deploy src/delulu_sandbox_modal/app.py\` only auto-mounts the **entry file** (\`app.py\`) at \`/root/app.py\` inside each container. Sibling modules in the same package (\`repo_provisioner.py\`, \`events.py\`) are not auto-bundled — Modal doesn't introspect imports.

The existing setup worked before Phase 1 because \`app.py\`'s only \`from delulu_sandbox_modal import ...\` was under \`TYPE_CHECKING\` (for \`events.Event\` type hints), which never runs at import time. Phase 1 introduced an actual runtime import inside \`provision_workspace\`, which surfaced the gap as soon as the function was actually invoked.

## Fix
Add \`.add_local_python_source(\"delulu_sandbox_modal\")\` to both \`sandbox_image\` and \`provisioner_image\`. This tells Modal to bundle the whole local package into the container on a path that's in \`PYTHONPATH\` (\`/root/delulu_sandbox_modal/\`), so the runtime import resolves.

Added to both images defensively — only \`provisioner_image\` is strictly needed today (\`run_claude_code\` doesn't directly import \`repo_provisioner\`), but future changes might, and the cost of bundling ~1KB of pure-python source is negligible.

## Log evidence
From the failing production run (@delulu mention in a bound channel):

\`\`\`
2026-04-15T03:54:11 [info] session.created repo_url=https://github.com/leehanchung/SMILE-factory
2026-04-15T03:54:11 [info] task.new        repo_url=https://github.com/leehanchung/SMILE-factory
2026-04-15T03:54:11 [info] dispatch.start  repo_url=https://github.com/leehanchung/SMILE-factory
2026-04-15T03:54:16 [error] task.failed
...
File \"<ta-...>:/root/app.py\", line 238, in provision_workspace
ModuleNotFoundError: No module named 'delulu_sandbox_modal'
\`\`\`

The binding lookup, session creation, dispatch, and workspace derivation all work correctly. The slow path correctly calls \`provision_workspace.remote()\`. The crash is inside the second container the \`.remote()\` call spins up.

## Test plan
- [x] \`ruff format --check . && ruff check . && pytest\` on \`delulu_sandbox_modal\` → **43 passed**, ruff clean
- [ ] Merge this
- [ ] CD redeploys the Modal app automatically via the \`delulu-sandbox-modal-deploy\` workflow
- [ ] Re-run the failing test: \`@delulu whats in this repo\` in a channel bound to \`leehanchung/SMILE-factory\` → expect the status message to show \`📁 leehanchung/SMILE-factory@HEAD\` AND the bash tool to run against the checked-out repo (not an empty workspace)
- [ ] Follow-up PR: fix the \`AsyncUsageWarning\` noise from \`RepoConfig\` / \`RepoAllowlist\` blocking \`modal.Dict\` calls in async contexts (separate PR per user request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)