### PR TITLE
fix(bot): use modal.Dict.aio() variants to avoid blocking the event loop

### DIFF
--- a/apps/delulu_discord/src/delulu_discord/commands.py
+++ b/apps/delulu_discord/src/delulu_discord/commands.py
@@ -124,8 +124,8 @@ def register_slash_commands(
             )
             return
 
-        if not repo_allowlist.contains(interaction.guild_id, repo):
-            current = repo_allowlist.get(interaction.guild_id)
+        if not await repo_allowlist.contains(interaction.guild_id, repo):
+            current = await repo_allowlist.get(interaction.guild_id)
             if current:
                 listing = "\n".join(f"  • `{r}`" for r in current)
                 msg = (
@@ -145,7 +145,7 @@ def register_slash_commands(
         # needs this form for `git clone`; the bot's display code
         # parses owner/repo back out of it via _short_repo_name.
         full_url = f"https://github.com/{repo}"
-        repo_config.set(interaction.channel_id, full_url, ref)
+        await repo_config.set(interaction.channel_id, full_url, ref)
 
         await interaction.response.send_message(
             f"✅ Channel bound to `{repo}@{ref}`. "
@@ -161,7 +161,7 @@ def register_slash_commands(
         if interaction.guild_id is None:
             return []
         return _build_autocomplete_choices(
-            repo_allowlist.get(interaction.guild_id),
+            await repo_allowlist.get(interaction.guild_id),
             current,
         )
 
@@ -178,7 +178,7 @@ def register_slash_commands(
             )
             return
 
-        repo_config.unset(interaction.channel_id)
+        await repo_config.unset(interaction.channel_id)
         await interaction.response.send_message(
             "✅ Channel unbound. New `@claude` mentions will run with no repo (general Q&A mode).",
             ephemeral=True,
@@ -221,7 +221,7 @@ def register_slash_commands(
             )
             return
 
-        repo_allowlist.add(interaction.guild_id, repo)
+        await repo_allowlist.add(interaction.guild_id, repo)
         await interaction.followup.send(
             f"✅ `{repo}` added to this server's allowlist.\nUsers can now `/setrepo` against it.",
             ephemeral=True,
@@ -243,14 +243,14 @@ def register_slash_commands(
             return
 
         repo = repo.strip()
-        if not repo_allowlist.contains(interaction.guild_id, repo):
+        if not await repo_allowlist.contains(interaction.guild_id, repo):
             await interaction.response.send_message(
                 f"`{repo}` isn't on this server's allowlist — nothing to remove.",
                 ephemeral=True,
             )
             return
 
-        repo_allowlist.remove(interaction.guild_id, repo)
+        await repo_allowlist.remove(interaction.guild_id, repo)
         await interaction.response.send_message(
             f"✅ `{repo}` removed from this server's allowlist.\n\n"
             "*Note: existing channel bindings to this repo are NOT cleared. "
@@ -266,7 +266,7 @@ def register_slash_commands(
         if interaction.guild_id is None:
             return []
         return _build_autocomplete_choices(
-            repo_allowlist.get(interaction.guild_id),
+            await repo_allowlist.get(interaction.guild_id),
             current,
         )
 
@@ -284,7 +284,7 @@ def register_slash_commands(
             )
             return
 
-        current = repo_allowlist.get(interaction.guild_id)
+        current = await repo_allowlist.get(interaction.guild_id)
         if not current:
             await interaction.response.send_message(
                 "*This server has no allowed repos yet. Add one with `/admin_addrepo`.*",

--- a/apps/delulu_discord/src/delulu_discord/handlers.py
+++ b/apps/delulu_discord/src/delulu_discord/handlers.py
@@ -48,7 +48,7 @@ class MessageHandler:
         thread_name = prompt[:50].strip() or "Claude Code task"
         thread = await message.create_thread(name=thread_name)
 
-        binding = self.repo_config.get(message.channel.id)
+        binding = await self.repo_config.get(message.channel.id)
         if binding is None:
             repo_url, ref = None, self.settings.default_git_ref
         else:

--- a/apps/delulu_discord/src/delulu_discord/repo_allowlist.py
+++ b/apps/delulu_discord/src/delulu_discord/repo_allowlist.py
@@ -38,33 +38,38 @@ DICT_NAME = "discord-orchestrator-allowlist"
 
 
 class RepoAllowlist:
-    """Modal-Dict-backed per-guild repo allowlist."""
+    """Modal-Dict-backed per-guild repo allowlist.
+
+    All methods are **async** for the same reason as ``RepoConfig``:
+    blocking ``modal.Dict`` calls stall discord.py's event loop.
+    See the RepoConfig docstring for the full rationale.
+    """
 
     def __init__(self) -> None:
         self._dict = modal.Dict.from_name(DICT_NAME, create_if_missing=True)
 
-    def get(self, guild_id: int) -> list[str]:
+    async def get(self, guild_id: int) -> list[str]:
         """Return the allowlist for a guild (empty list if unset).
 
         Used by ``/setrepo`` autocomplete + validation, and by
         ``/admin_listrepos`` to show the current state.
         """
-        return list(self._dict.get(guild_id) or [])
+        return list(await self._dict.get.aio(guild_id) or [])
 
-    def add(self, guild_id: int, owner_repo: str) -> None:
+    async def add(self, guild_id: int, owner_repo: str) -> None:
         """Add an entry to a guild's allowlist. Idempotent."""
-        current = self.get(guild_id)
+        current = await self.get(guild_id)
         if owner_repo in current:
             return
         current.append(owner_repo)
-        self._dict[guild_id] = current
+        await self._dict.put.aio(guild_id, current)
         logger.info(
             "repo_allowlist.add",
             guild_id=guild_id,
             owner_repo=owner_repo,
         )
 
-    def remove(self, guild_id: int, owner_repo: str) -> None:
+    async def remove(self, guild_id: int, owner_repo: str) -> None:
         """Remove an entry from a guild's allowlist. No-op if not present.
 
         Note: does NOT retroactively unbind channels that were
@@ -74,17 +79,17 @@ class RepoAllowlist:
         check, so the recovery path is "rebind to an allowed repo or
         unbind manually."
         """
-        current = self.get(guild_id)
+        current = await self.get(guild_id)
         if owner_repo not in current:
             return
         current.remove(owner_repo)
-        self._dict[guild_id] = current
+        await self._dict.put.aio(guild_id, current)
         logger.info(
             "repo_allowlist.remove",
             guild_id=guild_id,
             owner_repo=owner_repo,
         )
 
-    def contains(self, guild_id: int, owner_repo: str) -> bool:
+    async def contains(self, guild_id: int, owner_repo: str) -> bool:
         """True iff ``owner_repo`` is on ``guild_id``'s allowlist."""
-        return owner_repo in self.get(guild_id)
+        return owner_repo in await self.get(guild_id)

--- a/apps/delulu_discord/src/delulu_discord/repo_config.py
+++ b/apps/delulu_discord/src/delulu_discord/repo_config.py
@@ -31,28 +31,43 @@ DICT_NAME = "discord-orchestrator-repo-config"
 
 
 class RepoConfig:
-    """Modal-Dict-backed channel→(repo_url, ref) binding store."""
+    """Modal-Dict-backed channel→(repo_url, ref) binding store.
+
+    All methods are **async** because the bot runs on discord.py's
+    asyncio event loop. Using ``modal.Dict``'s blocking dict-style
+    API (``d.get(key)``, ``d[key] = value``, ``d.pop(key)``) from
+    within a coroutine stalls the event loop for the duration of
+    the Modal round-trip (~50–200ms per call), which freezes every
+    other async task in the bot — gateway heartbeats, inbound
+    messages, slash-command interactions. Modal surfaces this as
+    ``AsyncUsageWarning``.
+
+    The fix is to use modal.Dict's ``.aio`` variants, which return
+    awaitables. Each blocking method on ``modal.Dict`` exposes an
+    ``.aio`` attribute that's the async version of the same call —
+    e.g. ``d.get.aio(key)`` returns a coroutine.
+    """
 
     def __init__(self) -> None:
         self._dict = modal.Dict.from_name(DICT_NAME, create_if_missing=True)
 
-    def get(self, channel_id: int) -> tuple[str, str] | None:
+    async def get(self, channel_id: int) -> tuple[str, str] | None:
         """Return ``(repo_url, ref)`` for a channel, or ``None`` if unbound.
 
         Used by the message handler at thread-creation time. Returning
         ``None`` is the "general Q&A mode" sentinel — the dispatch
         proceeds with an empty workspace and no git operations.
         """
-        raw = self._dict.get(channel_id)
+        raw = await self._dict.get.aio(channel_id)
         if raw is None:
             return None
         # Stored as a small dict so the schema is self-describing in
         # Modal's UI and survives field additions.
         return raw["repo_url"], raw["ref"]
 
-    def set(self, channel_id: int, repo_url: str, ref: str = "HEAD") -> None:
+    async def set(self, channel_id: int, repo_url: str, ref: str = "HEAD") -> None:
         """Bind a channel to ``(repo_url, ref)``. Overwrites any existing binding."""
-        self._dict[channel_id] = {"repo_url": repo_url, "ref": ref}
+        await self._dict.put.aio(channel_id, {"repo_url": repo_url, "ref": ref})
         logger.info(
             "repo_config.set",
             channel_id=channel_id,
@@ -60,12 +75,12 @@ class RepoConfig:
             ref=ref,
         )
 
-    def unset(self, channel_id: int) -> None:
+    async def unset(self, channel_id: int) -> None:
         """Remove a channel's binding. No-op if not present."""
         # `pop` on modal.Dict raises KeyError if missing; swallow it
         # so callers don't have to special-case the no-binding path.
         try:
-            self._dict.pop(channel_id)
+            await self._dict.pop.aio(channel_id)
             logger.info("repo_config.unset", channel_id=channel_id)
         except KeyError:
             pass


### PR DESCRIPTION
## Summary
Converts \`RepoConfig\` and \`RepoAllowlist\` to async and uses \`modal.Dict\`'s \`.aio()\` variants so blocking Modal calls no longer stall discord.py's event loop. Fixes the \`AsyncUsageWarning\` noise that showed up in the bot logs right after Phase 2 shipped.

Separate PR per user request so the sandbox module-path fix (PR #50) and this cleanup ship independently.

## Root cause
The Phase 2 data classes used modal.Dict's dict-style shorthand API (\`d.get(k)\`, \`d[k] = v\`, \`d.pop(k)\`) from inside discord.py's asyncio event loop. Each call stalled the loop for 50–200ms while Modal talked to its backend, which Modal correctly flagged with:

\`\`\`
AsyncUsageWarning: A blocking Modal interface is being used in an async context.
Suggested rewrite:
  raw = await self._dict.get.aio(channel_id)
\`\`\`

Not causing observable outages at current load (single-user, sparse traffic) but a latent issue that would bite under any concurrency — every stall freezes gateway heartbeats, other users' slash commands, and any in-flight handlers.

## Fix
Each blocking method on \`modal.Dict\` exposes an \`.aio\` attribute that's the coroutine version of the same call. Convert every method on the two data classes to \`async def\` and use \`.aio()\` for every dict operation:

| Before | After |
|---|---|
| \`self._dict.get(k)\` | \`await self._dict.get.aio(k)\` |
| \`self._dict[k] = v\` | \`await self._dict.put.aio(k, v)\` |
| \`self._dict.pop(k)\` | \`await self._dict.pop.aio(k)\` |

Then thread \`await\` through every call site in \`handlers.py\` (1 call site) and \`commands.py\` (11 call sites across all 5 slash commands + 2 autocomplete callbacks).

## Files changed
- \`repo_config.py\` — \`get/set/unset\` become \`async def\`, use \`.aio\` variants
- \`repo_allowlist.py\` — \`get/add/remove/contains\` become \`async def\`, use \`.aio\` variants. \`add\`/\`remove\` await the internal \`get()\` call since it's now a coroutine
- \`handlers.py\` — one \`await\` added to the \`RepoConfig.get\` call in \`handle_channel_message\`
- \`commands.py\` — 11 \`await\`s added across all slash command handlers and autocompletes

## Test plan
- [x] \`ruff format --check . && ruff check . && pytest\` on \`delulu_discord\` → **36 passed**, ruff clean
- [ ] Merge this
- [ ] CD rebuilds the bot Docker image and restarts the container
- [ ] After restart: \`docker logs disco | grep -c AsyncUsageWarning\` → should be **0**. Before this PR it was ~5 per minute during active use.

## Why no new tests
Testing async modal.Dict behavior requires either a real Modal client (no local fixture) or heavy mocking (both classes are such thin pass-throughs the mocks would just re-describe the implementation). The production indicator is the absence of \`AsyncUsageWarning\` in the bot logs after next restart — cheap to verify manually.

## Related
- Follow-up to #47 (Phase 2 — introduced the data classes)
- Companion to #50 (the sandbox \`add_local_python_source\` fix) — both were surfaced by the v1 smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)