### PR TITLE
docs: delulu usage guide + parking PRD for setrepo persistence bug

### DIFF
--- a/docs/delulu-usage.md
+++ b/docs/delulu-usage.md
@@ -1,0 +1,406 @@
+# Delulu — usage guide
+
+A hands-on guide to using the delulu Discord bot to run Claude Code
+against a repo from inside Discord. If you want the *design* of the
+bot, read [`ARCHITECTURE.md`](../ARCHITECTURE.md) at the repo root.
+If you're setting up a fresh deployment for the first time, read
+[`README.md`](../README.md) — this guide assumes the bot is already
+running in your server.
+
+## Quick command reference
+
+| Command | Who | What it does |
+|---|---|---|
+| `@delulu <prompt>` | anyone | Creates a thread and runs Claude Code against the current channel's bound repo (or an empty workspace if no binding). Top-level channel messages only — replies inside a thread don't need the mention. |
+| `/setrepo repo:owner/repo ref:HEAD` | anyone | Binds the current channel to a GitHub repo. Repo must be on the server's allowlist. |
+| `/unsetrepo` | anyone | Clears the channel's repo binding. New `@delulu` mentions fall back to empty-workspace general Q&A. |
+| `/commit message:<msg>` | anyone | Commits any pending changes in the current thread's workspace to a `claude/<thread-id>` branch and pushes to GitHub. Must be run inside an active thread. |
+| `/admin_addrepo repo:owner/repo` | Manage Server | Adds a public GitHub repo to the server's allowlist. Validates existence via the GitHub REST API at add time. |
+| `/admin_removerepo repo:owner/repo` | Manage Server | Removes a repo from the allowlist. Existing channel bindings are NOT retroactively cleared. |
+| `/admin_listrepos` | Manage Server | Ephemeral list of the current server's allowed repos. |
+
+Admin commands are gated by Discord's `MANAGE_GUILD` permission —
+users without it won't see them in autocomplete at all, so the
+command surface for regular members is just `@delulu`, `/setrepo`,
+`/unsetrepo`, and `/commit`.
+
+## The mental model in three sentences
+
+1. A server has an **allowlist** of repos that admins can curate.
+   Regular users can only bind channels to repos on that list.
+2. A **channel** is bound to at most one repo at a time. `@delulu`
+   mentions in that channel run against the bound repo; `@delulu`
+   mentions in an unbound channel run in an empty workspace for
+   general Q&A.
+3. Each `@delulu` mention creates a **thread**, and that thread
+   stays attached to the same worktree until its session expires.
+   Replies inside the thread auto-continue Claude Code's session,
+   and `/commit` from inside the thread pushes whatever Claude left
+   in the worktree to a branch on the upstream repo.
+
+The allowlist is per-server. The binding is per-channel. The
+workspace is per-thread.
+
+## One-time server setup (admins)
+
+Assuming the bot is already installed in your server and the
+server admin has the `MANAGE_GUILD` permission (given to Discord
+admins by default):
+
+### 1. Add a repo to the allowlist
+
+```
+/admin_addrepo repo:leehanchung/SMILE-factory
+```
+
+Expected: `✅ leehanchung/SMILE-factory added to this server's
+allowlist. Users can now /setrepo against it.`
+
+The bot validates the repo exists by calling
+`api.github.com/repos/<owner>/<repo>` — if the repo is private,
+doesn't exist, or GitHub rate-limits you, the command refuses with
+a specific error and the allowlist is unchanged.
+
+### 2. Verify the allowlist
+
+```
+/admin_listrepos
+```
+
+Expected: an ephemeral reply listing every allowed repo. Only you
+see it.
+
+### 3. Share with the channel
+
+That's all the admin has to do. Tell the channel members to
+`/setrepo` against one of the allowed repos and they're off.
+
+### Removing a repo
+
+```
+/admin_removerepo repo:leehanchung/SMILE-factory
+```
+
+The `repo:` argument autocompletes from the current allowlist, so
+you don't have to remember or type the exact name — type `/admin_removerepo`
+then pick from the dropdown.
+
+**Heads up:** removing a repo from the allowlist does NOT
+retroactively clear channels that were already `/setrepo`'d against
+it. Those threads keep their binding until someone runs `/unsetrepo`
+in those channels manually. Future `/setrepo` calls against the
+removed repo will fail the allowlist check.
+
+## Day-to-day usage (everyone)
+
+### Bind a channel to a repo
+
+Once a server admin has added a repo to the allowlist, anyone can
+bind it to a channel:
+
+```
+/setrepo repo:leehanchung/SMILE-factory
+```
+
+Or, if you want to work against a specific branch rather than the
+default:
+
+```
+/setrepo repo:leehanchung/SMILE-factory ref:my-branch
+```
+
+The `repo:` argument autocompletes from the server's allowlist, so
+type `/setrepo` and pick from the dropdown — no need to type the
+exact repo name. If you try to bind a repo that's not on the
+allowlist, the bot replies with the current list and tells you to
+ask an admin to add it.
+
+**Where you run `/setrepo` matters.** Run it from the **top-level
+channel view**, not inside an existing thread. Discord's
+`interaction.channel_id` is whichever view you're in at the moment
+you invoke the slash command, and if you run it from inside a
+thread, the binding gets stored against the thread ID rather than
+the channel ID. The bot will then look up the channel ID when
+someone `@delulu` mentions it in the channel root, find nothing,
+and fall back to empty-workspace mode.
+
+If you think `/setrepo` worked but `@delulu` is running in an
+empty workspace, that's the first thing to check.
+
+### Run Claude Code against the repo
+
+In the same channel:
+
+```
+@delulu summarize the top-level structure of the repo
+```
+
+Three things happen:
+
+1. The bot creates a new Discord thread off your message, named
+   after the first ~50 characters of your prompt.
+2. A status message appears inside the thread. Line 1 is
+   `💭 Thinking about your request...` (replaced by Claude's
+   reasoning spoiler once it starts thinking). Line 2 is
+   `📁 leehanchung/SMILE-factory@HEAD` — the active-repo
+   subtitle, always visible right under the thinking header while
+   the run is alive.
+3. Claude Code starts running in the repo's worktree. Tool calls
+   stream into the status message in place:
+   `🔧 Glob *.md`, `🔧 Read README.md`, `🔧 Edit src/foo.py`, etc.
+   Each one gets a `✓` or `✗` tick when it returns.
+
+On completion the status message freezes with a
+`✅ Done • N tools • Xs` footer appended to the end of the
+transcript. The transcript stays visible — it doesn't collapse.
+
+The first `@delulu` mention ever against a given repo is a **cold
+start** — the bot clones the bare repo into a shared cache
+(`/vol/repo-cache/github.com/<owner>/<repo>.git`) with
+`--filter=blob:none` so file contents aren't fetched until someone
+opens them. Expect ~8–15 seconds before Claude starts producing
+tool calls, depending on repo size. Subsequent threads against the
+same repo are a **warm start** — just a worktree creation, ~3–5
+seconds.
+
+### Follow up in the thread
+
+Once the initial response arrives, reply in the thread **without**
+`@delulu`:
+
+```
+now find the slowest test in the suite
+```
+
+The bot resumes Claude Code's session via `claude --continue`, so
+the follow-up has the full context of the prior turn. The warm
+path skips the worktree creation entirely via a marker file —
+expect ~2–4 seconds before Claude starts.
+
+Session continuity is per-thread and keyed on the thread ID.
+Replies in the SAME thread continue the session; a new `@delulu`
+mention at the channel root starts a fresh thread with a fresh
+session, even if the new thread targets the same repo.
+
+### Commit and push changes back
+
+If Claude has made edits to the workspace (via `Edit`, `Write`, or
+other file-mutating tools), you can push those changes back to
+GitHub without leaving Discord. From inside the thread:
+
+```
+/commit message:fix: claude's proposed refactor
+```
+
+The bot makes a commit on a `claude/<thread-id>` branch (creating
+it if it doesn't exist yet) and pushes to the upstream repo. On
+success, you get a reply like:
+
+```
+✅ Committed `a1b2c3d` and pushed to branch `claude/1493821717049643058`.
+
+Open a PR: https://github.com/leehanchung/SMILE-factory/compare/main...claude/1493821717049643058?expand=1
+```
+
+Click the compare URL to land on GitHub's "Open a pull request"
+page, where you can review the diff, set a title and description,
+and merge when you're ready. The commit author shows as `Claude
+Code <claude@bot.local>` by default (configurable via Modal
+secrets); the *pusher* shows as whoever owns the `github-pat`
+token in the Modal secret — not whoever typed `/commit` in
+Discord. See [README.md](../README.md) for how to set up the PAT
+secret and customize the author identity.
+
+Edge cases to know:
+
+- **`/commit` with no pending changes** → `ℹ️ Nothing to commit
+  — the workspace has no pending changes.` The command is
+  idempotent; you can re-run it safely.
+- **`/commit` with no PAT configured** → `❌ Can't commit —
+  github-pat Modal secret missing or empty.` The bot shows you the
+  exact `modal secret create` command to run. Your workspace is
+  untouched — no hidden partial commit, nothing lost.
+- **`/commit` in a channel (not a thread)** → `❌ /commit must be
+  run inside a Claude Code thread.` Scroll into the thread first.
+- **`/commit` in a thread with no repo binding** → `❌ This thread
+  has no repo binding.` Can happen for legacy threads created
+  before `/setrepo` was bound to the channel. Start a fresh
+  `@delulu` mention in the now-bound channel.
+
+### Clear the binding
+
+If you want to stop running `@delulu` against a repo and fall back
+to general Q&A mode in the channel:
+
+```
+/unsetrepo
+```
+
+Now `@delulu tell me a joke` in the same channel will create a
+thread with no `📁` subtitle line and run Claude in an empty
+workspace with no git operations. This is the legacy "Claude as a
+general assistant" behavior the bot shipped with pre-repo-provisioning.
+
+## The permission model, briefly
+
+Discord enforces slash command permissions server-side via
+`@app_commands.default_permissions`. Users without the required
+permission don't even **see** the gated commands in autocomplete —
+they're hidden, not just error-guarded.
+
+- **`MANAGE_GUILD`** — the "Manage Server" permission, held by
+  server owners, admins, and moderators with the role. This gates
+  `/admin_addrepo`, `/admin_removerepo`, and `/admin_listrepos`.
+- **No permission gate** — `/setrepo`, `/unsetrepo`, `/commit`, and
+  `@delulu` are available to everyone who can see the bot. Bindings
+  are per-channel, so anyone who can see a channel can rebind it;
+  if you want to gate that further, lean on Discord's channel
+  permissions rather than the bot.
+
+The allowlist is the main access-control layer: even though any
+channel member can `/setrepo`, they can only set to repos that an
+admin put on the allowlist. If you trust your admins, you trust
+the allowlist, you trust the bindings.
+
+## Multi-thread / multi-channel usage
+
+The binding is per-channel. If you have two channels — `#api-work`
+bound to `alice/api-service` and `#frontend-work` bound to
+`alice/frontend` — `@delulu` in each channel runs against the
+right repo automatically, with the corresponding `📁` subtitle in
+each thread's status message.
+
+Each `@delulu` mention creates a new thread with its own workspace
+under `/vol/workspaces/<thread-id>` on the Modal volume. Two
+threads in the same channel don't share state — they're independent
+checkouts of the same repo. You can have parallel threads working
+on different parts of the same codebase without stepping on each
+other.
+
+If the same repo is bound in multiple channels and multiple
+threads are dispatched at once, the **first** cold clone happens
+in whichever thread gets there first; subsequent threads hit the
+warm cache and skip the clone. The first-clone thread may feel
+slower than usual (~8–15s vs ~3–5s).
+
+## Troubleshooting
+
+### `@delulu` replies but says "working directory is empty"
+
+The channel's binding isn't being applied. Three things to check:
+
+1. **Did `/setrepo` succeed in this channel?** Run `/setrepo` again
+   at the **channel root** (not inside any thread) and confirm the
+   ephemeral `✅ Channel bound…` reply.
+2. **Are you in a new thread?** Bindings apply at thread-creation
+   time. If you've already started a thread before `/setrepo`, that
+   thread's session was created with no binding and won't
+   retroactively pick one up. Start a fresh `@delulu` mention at
+   the channel root.
+3. **Did the bot restart recently?** There's a known bug tracked
+   in [`prd/setrepo-persistence-bug.md`](../prd/setrepo-persistence-bug.md)
+   where bindings can be lost across bot restarts. If you saw the
+   bot container cycle recently, re-run `/setrepo` and try again.
+
+### The repo subtitle is showing but Claude says files are missing
+
+Check the `ref:` you bound to. If the branch or ref you specified
+doesn't exist on the upstream, the cold clone step will fail and
+you'll see an error in the thread. If the ref exists but is very
+sparse (e.g. an unrelated orphan branch), that's what Claude will
+see.
+
+Fix: `/unsetrepo`, then `/setrepo` again with the correct ref (or
+omit `ref:` entirely to use the default branch).
+
+### `/commit` fails with `push_failed`
+
+The local commit succeeded but the push was rejected. Most
+commonly:
+
+- **Expired PAT** — the `github-pat` Modal secret's token is past
+  its expiration date. Rotate: generate a new fine-grained PAT,
+  run `modal secret create github-pat GITHUB_TOKEN=<new> --force`,
+  redeploy the sandbox app. Your prior `/commit` attempts are
+  preserved on the `claude/<thread-id>` branch locally on the
+  volume, so the next successful push will include everything.
+- **Insufficient PAT scope** — the PAT needs `Contents: Read and
+  write` on the specific repo. If you narrowed repo access when
+  generating it, make sure the repo you're pushing to is in the
+  selected list.
+- **Branch protection** — `main` or `master` has branch protection
+  rules that block the push. This shouldn't happen for a
+  `claude/<thread-id>` branch (protection rules usually target
+  `main`/`master`), but check if you've set up blanket rules.
+
+The bot surfaces the git error message verbatim in the Discord
+reply, so whatever git says is the starting point for debugging.
+
+### Slash commands aren't showing up in autocomplete
+
+Discord's global slash command sync takes a few minutes to
+propagate after the bot starts. If it's been longer than ~10
+minutes and commands still aren't showing:
+
+```bash
+ssh root@<droplet> 'docker logs disco 2>&1 | grep commands.'
+```
+
+Look for `commands.registered count=6` and `commands.synced
+count=6`. If either is missing or shows `count=0`, the bot didn't
+successfully register commands — check the log lines just before
+for a traceback and follow that.
+
+### Everything looks right but `@delulu` just sits there
+
+Check the bot is actually running:
+
+```bash
+docker ps --format '{{.Image}}\t{{.Status}}' | grep disco
+```
+
+If the container is missing or stopped, restart it from the
+droplet's `/root/SMILE-factory` checkout:
+
+```bash
+make -C apps/delulu_discord deploy
+```
+
+If the container is running but not responding, tail the logs:
+
+```bash
+docker logs -f disco
+```
+
+Anything from a failed Modal dispatch (OAuth issues, sandbox
+timeouts) will show up there as a traceback.
+
+## Known limitations (v1)
+
+Documented in the PRD at [`prd/repo-provisioning.md`](../prd/repo-provisioning.md)
+under "Out of scope — park for v2":
+
+- **Public repos only.** Cloning private repos requires
+  auth-rewriting at clone time, which v1 doesn't do.
+- **Single shared PAT.** All commits go through one
+  GitHub identity (whoever owns the `github-pat` secret). Real
+  multi-user attribution via GitHub App installation tokens is a
+  v2 project.
+- **No workspace GC.** `/vol/workspaces/<thread-id>/` directories
+  accumulate indefinitely. The volume is big enough to not care
+  for now, but eventually a TTL or manual cleanup is needed.
+- **`/setrepo` doesn't persist across bot restarts** — see
+  [`prd/setrepo-persistence-bug.md`](../prd/setrepo-persistence-bug.md).
+  Workaround: re-run `/setrepo` after the bot restarts.
+- **Global provisioning serialization.** Cold clones on different
+  repos queue up behind each other via `@app.function(max_containers=1)`
+  on `provision_workspace`. Fine for a solo user; would need
+  per-repo concurrency primitives for a larger deployment.
+
+## Getting help
+
+- **Architecture questions** → [`ARCHITECTURE.md`](../ARCHITECTURE.md)
+- **Deployment questions** → [`README.md`](../README.md)
+- **Design decisions** → the PRDs under [`prd/`](../prd/)
+- **Anything going wrong** → `docker logs disco` on the droplet is
+  the single best source of truth for what the bot is doing

--- a/prd/setrepo-persistence-bug.md
+++ b/prd/setrepo-persistence-bug.md
@@ -1,0 +1,203 @@
+# `/setrepo` binding lost after bot restart
+
+Known regression in the repo-provisioning v1 feature set, surfaced
+by the post-ship smoke test of Phases 1–4. Writeup here so the bug
+is tracked until we have bandwidth to chase it properly — fix is
+almost certainly one line, but I want to verify the hypothesis
+empirically rather than guess.
+
+This is a *plan*, not a fix. Nothing in this document is in the
+code yet.
+
+## Symptom
+
+1. User runs `/setrepo repo:leehanchung/SMILE-factory` in a channel.
+2. Bot replies ephemerally with `✅ Channel bound to
+   leehanchung/SMILE-factory@HEAD. New @claude mentions in this
+   channel will run against this repo.`
+3. `@delulu whats in this repo` works correctly — the LiveStatus
+   shows the `📁 leehanchung/SMILE-factory@HEAD` subtitle and the
+   sandbox provisions a real worktree.
+4. Bot container restarts (CD push, manual `docker restart`, or
+   crash recovery).
+5. User runs `@delulu whats in this repo` again. The bot falls
+   through to the no-repo fast path — empty workspace, no subtitle
+   line, Claude reports "working directory is empty." The binding
+   is gone.
+6. `/setrepo` re-run succeeds and re-binds. So the storage layer
+   is writable; something about the persistence is wrong.
+
+## Why this shouldn't be happening
+
+`RepoConfig` is backed by `modal.Dict.from_name(
+"discord-orchestrator-repo-config", create_if_missing=True)`. Modal
+Dicts are durable — writes persist on Modal's side across bot
+restarts by design. A bot process holding a stale handle to a Modal
+Dict that was later wiped is the only sane way this would "forget,"
+and we never call `.clear()` anywhere.
+
+So either:
+
+1. **Writes aren't actually persisting.** `/setrepo` thinks it
+   succeeded (user sees the ✅) but the underlying `modal.Dict`
+   write is silently no-op-ing.
+2. **Reads are looking at the wrong dict.** The bot reconnects to
+   a different backing store after restart — different environment,
+   different dict name, different client auth.
+3. **Writes and reads are both fine but something else is clearing
+   the dict.** Unlikely given no code path does this, but worth
+   ruling out.
+
+## Suspected root cause
+
+**Option 1 (writes silently failing) is the most likely.** PR #51
+converted `RepoConfig.set` from the blocking dict-style shorthand
+to an async `.aio()` call:
+
+```python
+# Before (pre-PR #51)
+self._dict[channel_id] = {"repo_url": repo_url, "ref": ref}
+
+# After (PR #51)
+await self._dict.put.aio(channel_id, {"repo_url": repo_url, "ref": ref})
+```
+
+Modal's own `AsyncUsageWarning` on the pre-#51 code suggested
+`await ...__setitem__.aio(...)` as the rewrite. I guessed `put.aio`
+as a cleaner equivalent. If `put.aio(key, value)` has different
+semantics from `__setitem__.aio(key, value)` — or doesn't exist at
+all on `modal.Dict` — the write silently drops.
+
+**Evidence that would confirm this:**
+
+- `modal dict items discord-orchestrator-repo-config` returns an
+  empty dict (or is missing entries for the channels that were
+  `/setrepo`'d)
+- Bot logs show `repo_config.set` firing (from the `structlog.info`
+  call) but no corresponding Modal-side error
+
+**Evidence that would rule this out:**
+
+- The dict dump shows the expected entries, which means writes
+  DID persist and reads are the broken path — pointing at Option 2
+  or 3
+
+`RepoAllowlist.add` and `.remove` use the same `put.aio` pattern, so
+if this theory is right, **admin commands are also broken in the
+same way**. Users haven't complained yet because `/admin_addrepo`
+gets verified via a fresh `/admin_listrepos` in the same session,
+where the in-process cache papers over the missing persistence.
+After a bot restart the admin-added repos should also vanish.
+
+## Diagnostic plan
+
+Before changing any code, run this and capture the output:
+
+```bash
+# Dump the repo-config and allowlist dicts
+modal dict items discord-orchestrator-repo-config
+modal dict items discord-orchestrator-allowlist
+
+# Check bot logs for the write path
+docker logs disco 2>&1 | grep -E "repo_(config|allowlist)\." | tail -20
+
+# Check for any Modal errors the bot swallowed
+docker logs disco 2>&1 | grep -iE "(error|traceback|warning)" | tail -40
+```
+
+Then run `/setrepo repo:leehanchung/SMILE-factory` one more time
+and immediately re-run `modal dict items discord-orchestrator-repo-config`.
+
+- If the dict is still empty → writes are silently failing.
+  Proceed to the fix in "Candidate fixes" below.
+- If the dict has the expected entry → writes work. The bug is on
+  the read path or the key type. Escalate to a deeper read-path
+  investigation before applying any fix.
+
+## Candidate fixes
+
+### Fix 1 — use `__setitem__.aio` / `__delitem__.aio` literally
+
+Match Modal's own warning suggestion word-for-word rather than
+assuming the method name:
+
+```python
+# repo_config.py
+async def set(self, channel_id: int, repo_url: str, ref: str = "HEAD") -> None:
+    await self._dict.__setitem__.aio(channel_id, {"repo_url": repo_url, "ref": ref})
+
+async def unset(self, channel_id: int) -> None:
+    try:
+        await self._dict.__delitem__.aio(channel_id)
+    except KeyError:
+        pass
+```
+
+Same for `repo_allowlist.py`'s `add` and `remove`.
+
+This is ugly (calling dunder methods explicitly on the `.aio`
+accessor is not idiomatic), but it literally matches the warning's
+suggested rewrite from the pre-PR #51 code, so it's the lowest-risk
+change.
+
+### Fix 2 — go back to the blocking API and accept the warnings
+
+Revert PR #51's changes to use the sync dict-style shorthand. Loses
+the async-correctness wins, reintroduces the event-loop stalls, but
+proves persistence works and isolates the problem.
+
+Not a real fix — useful only as a bisection step if Fix 1 doesn't
+work.
+
+### Fix 3 — switch to `modal.Function`-based persistence
+
+Define a dedicated Modal function with `max_containers=1` keyed on
+guild_id, have it own the dict, and dispatch mutations through
+`.remote()`. This is what `provision_workspace` does for filesystem
+locks. Much heavier; only worth it if the dict-direct paths are
+fundamentally broken for async callers.
+
+Unlikely to be necessary. Listed for completeness.
+
+## Validation plan
+
+After applying Fix 1:
+
+1. Restart the bot container (forces a fresh `RepoConfig` instance)
+2. Run `/setrepo repo:leehanchung/SMILE-factory`
+3. `modal dict items discord-orchestrator-repo-config` → confirm
+   the entry is present
+4. Restart the bot container again
+5. `modal dict items discord-orchestrator-repo-config` → entry
+   should STILL be there (this is the bug's core symptom — writes
+   from a prior process should be visible to a new process)
+6. `@delulu whats in this repo` → expect the `📁` subtitle and a
+   real provisioned workspace, not the empty fast path
+7. Repeat the test for `/admin_addrepo` on `RepoAllowlist` — same
+   restart-across-a-bot-bounce test
+
+## Why this is parked, not fixed now
+
+The feature ships a degraded UX (users have to re-run `/setrepo`
+after every bot restart) but does NOT ship broken behavior — the
+refuse path is a clean re-bind, no data loss, no confusing state.
+The async warning fix in PR #51 was the right architectural move
+and shouldn't be reverted just to unblock the persistence path; the
+right move is a surgical fix to the put-path semantics.
+
+More importantly: the blocker was the module-path fix (PR #50),
+which IS shipped. Users can drive the repo-provisioning end-to-end
+in a single session. The persistence bug only bites on the second
+session after a restart, which is annoying but recoverable. Ship
+the feature, park the bug, fix in a follow-up when bandwidth
+allows.
+
+## Out of scope
+
+- Migrating off `modal.Dict` to another storage backend
+- Changing the schema of the stored binding
+- Changing the key type (we use `channel_id: int`, which modal.Dict
+  accepts; type mismatches are not the suspected issue)
+- A write-through cache on `RepoConfig` to paper over the bug
+  without fixing the underlying persistence — would hide real
+  storage failures in the future


### PR DESCRIPTION
## Summary
Two doc-only additions after the repo-provisioning v1 ship. No code changes.

## \`docs/delulu-usage.md\` (new, 406 lines)
A hands-on user guide for the bot. Covers the full flow from \`/admin_addrepo\` (admin one-time setup) through \`/setrepo\` → \`@delulu\` → \`/commit\` (push-back), with:

- **Quick command reference table** at the top — scan-friendly summary of all six slash commands, who can run them, and what they do
- **Three-sentence mental model** (allowlist → binding → thread) so new users understand the scoping without having to read the architecture doc
- **One-time server setup** section for admins (\`/admin_addrepo\` + \`/admin_listrepos\` + \`/admin_removerepo\` with the retroactive-unbind caveat)
- **Day-to-day usage** walkthrough — \`/setrepo\`, \`@delulu\` with the cold-vs-warm start timing notes, thread follow-ups via \`claude --continue\`, \`/commit\` happy path, \`/unsetrepo\` fallback to general Q&A
- **Permission model** explainer — how Discord hides gated commands via \`default_permissions(manage_guild=True)\` server-side
- **Multi-channel / multi-thread semantics** — two channels bound to different repos, parallel threads, shared cold clones
- **Troubleshooting section** driven by the failure modes surfaced during the v1 smoke test (empty workspace, missing subtitle, commit failures, slash commands not syncing)
- **Known limitations** linking to the v2 parking section of the repo-provisioning PRD

Lives in \`docs/\` to keep operational reference material separate from setup reference (\`README.md\`) and design material (\`ARCHITECTURE.md\`). The \`docs/\` directory already has \`architecture.md\`, \`development.md\`, and \`plan-deep-agent-rl.md\` for the LoRA-Instruct era; this adds the delulu equivalent.

## \`prd/setrepo-persistence-bug.md\` (new, 203 lines)
Parking doc for the regression where channel bindings are lost across bot restarts (surfaced by the post-ship smoke test). Follows the same style as the existing \`prd/cancel-run.md\` — a *plan*, not a spec of implemented behavior.

**Hypothesis**: PR #51's async fix replaced \`self._dict[k] = v\` with \`self._dict.put.aio(k, v)\`. Modal's own \`AsyncUsageWarning\` on the pre-PR-51 code suggested \`await ...__setitem__.aio(...)\` as the rewrite, not \`put.aio\`. If \`put.aio\` doesn't exist or has different semantics, writes silently drop. The \`/setrepo\` command shows its ✅ reply (the Discord interaction response) while the underlying Modal Dict write is a no-op.

The PRD lays out:
- **Symptom** — user-visible behavior with exact reproduction steps
- **Why it shouldn't happen** — Modal Dicts are durable by design
- **Suspected root cause** — the three options, with Option 1 (writes silently failing) as the leading theory
- **Diagnostic plan** — concrete \`modal dict items\` and \`docker logs\` commands to confirm/refute before touching code
- **Candidate fixes** — three options ordered by preference, with Fix 1 (use \`__setitem__.aio\` / \`__delitem__.aio\` literally) as the lowest-risk change
- **Validation plan** — restart-across-a-bot-bounce test that reproduces the exact failure mode
- **Why it's parked** — degraded UX (re-run \`/setrepo\` after restarts) but not broken behavior; the real blocker (PR #50, module-path) already shipped separately

## Test plan
- [x] Both files render correctly in the GitHub file viewer
- [x] Links between docs resolve (usage guide → PRD, PRD → v2 parking section of repo-provisioning PRD, both → README.md and ARCHITECTURE.md)
- [ ] Merge — doc-only, no CI impact beyond markdown rendering

## Intentional non-scope
- **Not fixing the setrepo persistence bug in this PR.** The fix is parked behind the PRD; need to dump the Modal Dict and verify the hypothesis first. A separate PR will ship the one-line fix once we have the diagnostic data.
- **Not updating README.md.** The usage guide is a separate entry point for "how do I use the bot" — README.md stays focused on "how do I install and deploy the bot."

🤖 Generated with [Claude Code](https://claude.com/claude-code)