### PR TITLE
fix(sandbox): allow Claude Code to edit files in non-interactive runs

### DIFF
--- a/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/app.py
+++ b/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/app.py
@@ -528,6 +528,28 @@ def run_claude_code(
         # --output-format stream-json requires --verbose in Claude Code;
         # without it, CC errors out before producing any events.
         "--verbose",
+        # Auto-accept all tool calls including file edits, writes, and
+        # bash commands. Without this flag, Claude Code runs in its
+        # default interactive permission mode, and in -p (non-interactive)
+        # mode that mode auto-REFUSES file-write tools with the canned
+        # "I don't have write permission" response. Read/Glob/Grep still
+        # work (they're always allowed), but the whole point of a code-
+        # editing bot is Edit/Write/Bash, so the default is broken for
+        # our use case.
+        #
+        # Safe because the Modal sandbox IS the trust boundary: each
+        # invocation is an ephemeral container with only the workspace
+        # volume mounted, no access to production systems, and a hard
+        # 300s wall-clock timeout. The only filesystem Claude can
+        # damage is the per-thread worktree at /vol/workspaces/<id>/,
+        # which the user is explicitly asking Claude to modify. The
+        # volume cap on damage is the bare cache itself — and provision
+        # runs in a separate container with its own serialization, so
+        # Claude inside run_claude_code can't race against it.
+        #
+        # Equivalent to --permission-mode bypassPermissions per the
+        # Claude Code CLI docs.
+        "--dangerously-skip-permissions",
     ]
     if resume:
         # --continue resumes the most recent Claude Code session in the cwd.


### PR DESCRIPTION
## Summary
Fixes the Phase 3+4 end-to-end smoke test regression where \`@delulu make an edit\` produces \`🔧 Read ✓\` → \`🔧 Edit ✗\` → \`🔧 Edit ✗\` → \"I don't have write permission to that file\" instead of actually editing the file.

## Root cause
The sandbox invokes Claude Code with:

\`\`\`
claude --print -p <prompt> --output-format stream-json --verbose
\`\`\`

No permission flag. That puts Claude Code in its default interactive permission mode. In non-interactive \`-p\` mode, the default auto-REFUSES file-write tools (\`Edit\`, \`Write\`, \`NotebookEdit\`) with the canned \"I don't have write permission, please grant access\" response. Read-only tools (\`Read\`, \`Glob\`, \`Grep\`) are always allowed, which is why the first tool call succeeds and gives the illusion that the workspace is accessible.

The filesystem IS writable — the worktree was freshly created by \`provision_workspace\` and the volume is mounted RW. This is Claude Code's own guardrail, not a Linux perms issue.

## Symptom from the live run
\`\`\`
🔧 Read .../README.md ✓
🔧 Edit .../README.md ✗
🔧 Edit .../README.md ✗
✅ Done • 3 tools • 25.2s
"It looks like I don't have write permission to that file.
 Could you grant edit access to README.md so I can make the
 change?"
\`\`\`

## Fix
Add \`--dangerously-skip-permissions\` to the \`cmd\` list in \`run_claude_code\`. Per the Claude Code CLI docs:

> \`--dangerously-skip-permissions\` — Skip permission prompts. Equivalent to \`--permission-mode bypassPermissions\`.

One-line functional change (plus a paragraph of comments explaining why it's safe in this specific context).

## Why the \"dangerous\" flag is appropriate here
The flag is named alarmingly because in the default interactive terminal use case it IS dangerous — a user probably doesn't want Claude auto-editing their real working copy without approval. But **the Modal sandbox is already the trust boundary**:

- Each invocation runs in an **ephemeral container** that dies after the run
- Only \`/vol\` is mounted — no access to production systems or secrets beyond what's explicitly passed via \`secrets=[...]\`
- **300-second wall-clock timeout** on the Modal function
- The only filesystem Claude can damage is the per-thread worktree at \`/vol/workspaces/<thread_id>/\`, which the user explicitly asked Claude to modify by mentioning \`@delulu\`
- The bare cache at \`/vol/repo-cache/\` is managed by \`provision_workspace\` in a **separate container** with its own serialization — \`run_claude_code\` can't race against it via Bash
- \`/commit\` runs in a **third container** with its own PAT pre-flight check and refuse-and-instruct path, so a mis-behaving Claude can't push garbage without a real PAT configured

So the alarming bit (\"could auto-modify your real repo\") doesn't apply — everything Claude can touch is pre-scoped to an ephemeral workspace the user explicitly created. The comment in the code spells this out so future-me doesn't remove the flag thinking it's unsafe.

## Test plan
- [x] \`ruff format --check . && ruff check . && pytest\` on \`delulu_sandbox_modal\` → **43 passed**, ruff clean
- [ ] Merge this → CD redeploys sandbox via \`delulu-sandbox-modal-deploy\`
- [ ] Re-run the failing test: \`@delulu make a one-line edit to README.md: add a comment at the top that says 'hello from claude'\` → expect \`🔧 Edit README.md ✓\` (not ✗) and Claude confirms the edit
- [ ] Follow up with \`/commit message:test: hello from claude\` to exercise the full push-back flow (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)