### PR TITLE
feat(sandbox): install gh CLI and expose PAT to run_claude_code

### DIFF
--- a/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/app.py
+++ b/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/app.py
@@ -42,7 +42,7 @@ sandbox_image = (
     # builder only supports Python 3.10–3.12. Set workspace-wide with:
     #   modal config set image_builder_version 2025.06
     modal.Image.debian_slim(python_version="3.14")
-    .apt_install("git", "curl")
+    .apt_install("git", "curl", "ca-certificates")
     # app.py is imported inside the sandbox to call run_claude_code, so any
     # third-party module it imports at module level must be present here too.
     .pip_install("structlog>=24.0")
@@ -52,6 +52,25 @@ sandbox_image = (
         "apt-get install -y nodejs",
         # Install Claude Code globally
         "npm install -g @anthropic-ai/claude-code",
+        # Install the GitHub CLI (`gh`) so Claude can push branches,
+        # open pull requests, list issues, etc. directly via its Bash
+        # tool when the user asks for things like "commit and open a
+        # PR." Uses GitHub's official apt repo — shorter install path
+        # than downloading the .deb manually and also gets security
+        # updates via `apt upgrade` on future image rebuilds.
+        "mkdir -p -m 755 /etc/apt/keyrings",
+        (
+            "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg "
+            "| tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null "
+            "&& chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg"
+        ),
+        (
+            'echo "deb [arch=$(dpkg --print-architecture) '
+            "signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] "
+            'https://cli.github.com/packages stable main" '
+            "| tee /etc/apt/sources.list.d/github-cli.list > /dev/null"
+        ),
+        "apt-get update && apt-get install -y gh",
     )
     # Bundle the whole `delulu_sandbox_modal` package into the image so
     # that runtime `from delulu_sandbox_modal import repo_provisioner`
@@ -376,10 +395,24 @@ def commit_workspace(thread_id: int, message: str) -> dict[str, Any]:
 
 
 # ── Modal Function (runs inside the sandbox) ─────────────────
+# `github_pat_secret` is attached here (in addition to
+# `commit_workspace`) so Claude can natively use `git push` and
+# `gh pr create` via its Bash tool when the user asks for things
+# like "commit and open a PR." Previously the PAT was only
+# available in the dedicated /commit flow; expanding access lets
+# the @claude natural-language path handle the full branch →
+# commit → push → PR loop without a slash command.
+#
+# Security note: the PAT becomes visible to any `run_claude_code`
+# invocation, not just `commit_workspace`. A rogue/prompt-injected
+# Claude has access to anything the PAT can do on the allowlisted
+# repos. For the v1 single-user scope this is acceptable; see
+# `prd/repo-provisioning.md`'s access-control section for why the
+# allowlist + narrow PAT scope is the primary defense.
 @app.function(
     image=sandbox_image,
     volumes={"/vol": volume},
-    secrets=[claude_oauth_secret],
+    secrets=[claude_oauth_secret, github_pat_secret],
     memory=4096,
     timeout=300,
 )
@@ -593,6 +626,28 @@ def run_claude_code(
     env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
     env["HOME"] = claude_home
     env["CLAUDE_PROJECT_DIR"] = workspace_path
+
+    # Surface the GitHub PAT to `gh` CLI and `git`. The `github-pat`
+    # Modal secret sets `GITHUB_TOKEN` in the container; `gh` also
+    # reads `GH_TOKEN` and prefers it. Setting both covers every
+    # codepath Claude's Bash tool might reach for (gh pr create,
+    # git push over HTTPS, etc.). If the secret value is a
+    # placeholder or empty, these env vars will be empty strings —
+    # gh/git will then refuse with their own clean error messages
+    # rather than accidentally authenticating as nobody.
+    github_token = env.get("GITHUB_TOKEN", "").strip()
+    if github_token and github_token != "placeholder":
+        env["GH_TOKEN"] = github_token
+        # Re-assign GITHUB_TOKEN in case the secret value had
+        # trailing whitespace — both gh and git are sensitive to that.
+        env["GITHUB_TOKEN"] = github_token
+    else:
+        # Scrub placeholder/empty values so `gh auth status` and
+        # `git push` fail cleanly with "not authenticated" instead
+        # of trying to use the literal string "placeholder" as a
+        # credential and getting a confusing 401.
+        env.pop("GH_TOKEN", None)
+        env.pop("GITHUB_TOKEN", None)
 
     logger.info(
         "sandbox.exec",


### PR DESCRIPTION
## Summary
Gives Claude (running inside \`run_claude_code\`) the ability to push and open pull requests directly via its Bash tool. After this PR, \`@delulu please commit this and open a PR\` works end-to-end in a single session — no slash command needed.

## What was broken
From the live smoke test:

\`\`\`
@delulu add it back and commit, push, and make a pr
...
🔧 Bash git push -u origin claude/1493835526862540970 ✗
🔧 Bash which gh && gh auth status 2>&1 ✗
✅ Done • 9 tools • 33.4s

There's no gh CLI or git credentials available in this
environment, so I can't push or create a PR from here.
\`\`\`

Two gaps:
1. No \`gh\` binary in the image
2. No \`GITHUB_TOKEN\` / \`GH_TOKEN\` in \`run_claude_code\`'s environment — only \`commit_workspace\` had the \`github-pat\` secret

## Design decision (recapped from the chat)
Considered adding the GitHub MCP server; went with \`gh\` CLI + PAT instead:

- **Simpler install** — one apt repo + one package, no MCP server process to manage
- **Claude already knows how to use \`gh\`** — tons of training data on \`gh pr create\`, \`gh issue list\`, etc. Natural language requests \"just work\" without needing to teach Claude which MCP tools correspond to which operations
- **The \`/commit\` slash command stays** as the structured/auditable path for \"make one clean commit\" flows; the natural-language \`@delulu\` path handles \"edit and open a PR\" flows. Both coexist.
- **v1 single-user scope makes the expanded PAT surface acceptable.** The primary defense is still the allowlist + narrow PAT scope documented in \`prd/repo-provisioning.md\`.

## What changed

### \`sandbox_image\`: install \`gh\` via GitHub's apt repo
Added to \`run_commands\`:
\`\`\`
mkdir -p -m 755 /etc/apt/keyrings
curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg
    | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
echo \"deb [arch=...] https://cli.github.com/packages stable main\"
    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
apt-get update && apt-get install -y gh
\`\`\`
Uses the official apt repo so future image rebuilds get security updates for free.

### \`run_claude_code\`: attach \`github_pat_secret\`
\`\`\`python
secrets=[claude_oauth_secret, github_pat_secret]
\`\`\`
Same secret \`commit_workspace\` already uses — no new Modal secret to create.

### Env vars: set both \`GH_TOKEN\` and \`GITHUB_TOKEN\`
After building the subprocess env dict, explicitly re-set both env vars:
- \`GH_TOKEN\` — preferred by the \`gh\` CLI
- \`GITHUB_TOKEN\` — used by \`git\`'s HTTPS auth fallback and as a fallback for \`gh\`

If the secret value is empty or the documented \`\"placeholder\"\` sentinel, **scrub both env vars from the subprocess env**. That way \`gh auth status\` / \`git push\` fail cleanly with \"not authenticated\" rather than trying to literally use the string \`\"placeholder\"\` as a bearer token. Also strips trailing whitespace on the PAT (Modal secret values can sneak in a trailing newline, both gh and git are sensitive to that).

## Security impact
The PAT is now visible to every \`run_claude_code\` invocation, not just \`commit_workspace\`. A rogue or prompt-injected Claude has access to whatever the PAT can do on the allowlisted repos (contents: read/write on the user's repos, per the screenshot of the PAT config earlier in the chat). For v1 single-user scope this is acceptable — documented inline in the code with a comment pointing at \`prd/repo-provisioning.md\`'s access-control section.

## What stays the same
- **\`/commit\` slash command**: unchanged, still structured, still refuse-and-instruct on missing PAT. Still the right tool for \"I iterated on this thread, make one clean commit.\"
- **\`commit_workspace\` Modal function**: unchanged, still uses its own copy of the secret.
- **The allowlist + bot-side permission model**: unchanged.

## Test plan
- [x] \`ruff format --check . && ruff check . && pytest\` on \`delulu_sandbox_modal\` → **51 passed**, ruff clean
- [ ] Merge this → CD redeploys sandbox via \`delulu-sandbox-modal-deploy\`
- [ ] Image rebuild includes \`gh\` install — watch CI logs for apt failures
- [ ] Re-run the failing test:
  \`\`\`
  @delulu add a one-line comment \"# hello from delulu\" at the top of README.md, commit it, push, and open a PR
  \`\`\`
  Expected: one \`@delulu\` session ends with the PR URL in Discord, Claude uses \`gh pr create\`, and the PR is visible on GitHub
- [ ] Confirm \`/commit\` still works (regression check for the structured path)
- [ ] \`@delulu gh auth status\` in a bound channel — should report authenticated to \`x-access-token\` on github.com, confirming the env var plumbing works

## Rollback
If something breaks, revert this PR. Claude goes back to edit-only (no push, no PR) and the structured \`/commit\` path still works for the commit flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)