### PR TITLE
fix(sandbox): put PAT in password field of push URL, not username

### DIFF
--- a/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/repo_provisioner.py
+++ b/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/repo_provisioner.py
@@ -516,47 +516,78 @@ def commit_workspace_changes(
     )
 
 
+# Placeholder username for URL-embedded PAT auth. Can be any
+# non-empty string — GitHub ignores the username field for PAT
+# auth and uses the password field (the actual PAT) to look up
+# the authenticated identity. ``git`` is innocuous, unambiguous,
+# and doesn't trigger any special routing on GitHub's auth layer.
+#
+# Do NOT use ``x-access-token`` here — that's the GitHub App
+# installation-token convention, and GitHub's auth layer routes
+# it to the App-token handler which expects a different token
+# format, then rejects PATs with a misleading "password
+# authentication not supported" error. See the docstring below
+# for the full saga.
+_PAT_URL_USERNAME = "git"
+
+
 def _build_push_url_with_pat(origin_url: str, github_token: str) -> str:
-    """Return the origin URL with the PAT embedded as the userinfo component.
+    """Return the origin URL with ``git:<pat>`` credentials embedded.
 
     Transforms ``https://github.com/owner/repo[.git]`` into
-    ``https://<pat>@github.com/owner/repo[.git]``.
+    ``https://git:<pat>@github.com/owner/repo[.git]``.
 
-    The PAT becomes the entire userinfo of the URL — **no username
-    prefix, no colon**. When git parses this, it sends an HTTP Basic
-    auth header with the PAT as the username and an empty password,
-    which is the form GitHub's server recognizes for PAT-over-HTTPS
-    auth.
+    The PAT is placed in the **password** field of the HTTP Basic
+    auth component, with ``git`` as a placeholder username. GitHub's
+    docs describe the interactive form as:
 
-    **Why not ``x-access-token:<pat>@...``?** An earlier version of
-    this function used ``x-access-token`` as the username (matching
-    the convention for GitHub App installation tokens). GitHub's
-    server would reject it with:
+        Username: YOUR-USERNAME
+        Password: YOUR-PERSONAL-ACCESS-TOKEN
 
-        remote: Invalid username or password. Password authentication
-        is not supported for Git operations.
+    Reference: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
 
-    The error message is misleading — the actual cause is that the
-    ``x-access-token`` username signals "I am a GitHub App" to
-    GitHub's auth layer, which then expects a GitHub App installation
-    token (different format from a Personal Access Token). The PAT
-    fails the App-token pattern match and GitHub falls back to the
-    generic "password authentication not supported" error. Using the
-    PAT as the whole userinfo sidesteps this pattern-matching
-    disaster entirely.
+    The username can be any non-empty string — GitHub ignores it and
+    looks up the authenticated user from the PAT — so we use ``git``
+    as an innocuous placeholder instead of the user's actual GitHub
+    handle (which the sandbox doesn't have in its environment).
 
-    GitHub documents this format directly:
+    **The saga of getting this right, for the next person who
+    touches this code:**
 
-        git clone https://TOKEN@github.com/USER/REPO
+    1. **First attempt (PR #56, first rev):** used ``http.extraheader``
+       with ``Authorization: Basic <base64(x-access-token:<pat>)>``.
+       Git intermittently fell through to the interactive credential
+       prompt and failed with "could not read Username: No such
+       device or address."
 
-    which is what we mirror here. Reference:
-    https://docs.github.com/en/get-started/git-basics/caching-your-github-credentials-in-git
+    2. **Second attempt (PR #56, second rev):** embedded
+       ``x-access-token:<pat>@github.com`` in the URL. GitHub's
+       server rejected it with "Invalid username or password.
+       Password authentication is not supported for Git operations."
+       Root cause: ``x-access-token`` is for GitHub App installation
+       tokens, not PATs — GitHub's auth layer routes it to the
+       App-token handler, which expects a different token format,
+       fails the pattern match, and falls back to a misleading error
+       message.
+
+    3. **Third attempt (PR #58):** used ``<pat>@github.com`` with no
+       username prefix, matching the ``https://TOKEN@github.com/...``
+       form that appears in some GitHub documentation. Git accepted
+       the token as the username (fair — it's the whole userinfo),
+       but GitHub's server rejected the empty password field and git
+       prompted for one interactively, failing with "could not read
+       Password: No such device or address."
+
+    4. **Fourth attempt (this function):** ``git:<pat>@github.com``.
+       Placeholder username + PAT as password. This matches what
+       GitHub's own docs describe for the interactive flow, and is
+       the canonical non-interactive equivalent. Should finally
+       work.
 
     Only HTTPS URLs are supported. SSH URLs (``git@github.com:…``)
-    don't have a natural place to stick a PAT because SSH auth is
-    keypair-based, not username/password. The ``/commit`` flow is
-    single-shared-PAT-only anyway (see the PRD's v1 scope notes),
-    so anything non-HTTPS is rejected loudly.
+    don't have a place for a PAT because SSH auth is keypair-based.
+    The ``/commit`` flow is single-shared-PAT-only anyway (see the
+    PRD's v1 scope notes), so anything non-HTTPS is rejected loudly.
     """
     from urllib.parse import urlparse, urlunparse
 
@@ -575,9 +606,9 @@ def _build_push_url_with_pat(origin_url: str, github_token: str) -> str:
     if not host:
         raise ValueError(f"cannot parse host from origin URL {origin_url!r}")
 
-    # Token-only userinfo — no username prefix. See the docstring
-    # for the "why not x-access-token" story.
-    netloc = f"{github_token}@{host}"
+    # ``<placeholder-username>:<pat>@host[:port]``. See the
+    # docstring for the fourth-attempt story.
+    netloc = f"{_PAT_URL_USERNAME}:{github_token}@{host}"
     if parsed.port:
         netloc = f"{netloc}:{parsed.port}"
 

--- a/apps/delulu_sandbox_modal/tests/test_repo_provisioner.py
+++ b/apps/delulu_sandbox_modal/tests/test_repo_provisioner.py
@@ -127,29 +127,25 @@ class TestParseRepoUrl:
 class TestBuildPushUrlWithPat:
     """URL-embedded PAT credentials for the /commit push path.
 
-    The token is embedded as the **entire userinfo** of the URL
-    (no username prefix, no colon-password split). This matches
-    GitHub's documented form:
+    The token is placed in the **password** field of the Basic auth
+    component, with ``git`` as a placeholder username:
 
-        git clone https://TOKEN@github.com/USER/REPO
+        https://git:<pat>@github.com/owner/repo
 
-    An earlier version used ``x-access-token:<pat>`` as the
-    userinfo, matching the GitHub App installation-token
-    convention. GitHub rejected that with a misleading
-    "password authentication not supported" error because the
-    ``x-access-token`` username routes to the App-token auth
-    handler, which expects a different token format. Using the
-    PAT as the whole userinfo sidesteps that pattern match.
+    See ``_build_push_url_with_pat``'s docstring for the full
+    four-attempt saga. The test_no_xaccesstoken_regression and
+    test_pat_in_password_not_username_field tests guard against
+    the two failure modes we've already hit.
     """
 
-    def test_https_github_url_gets_token_as_userinfo(self):
+    def test_https_github_url_gets_credentials_embedded(self):
         from delulu_sandbox_modal.repo_provisioner import _build_push_url_with_pat
 
         url = _build_push_url_with_pat(
             "https://github.com/alice/api-service.git",
             "ghp_abcdef123456",
         )
-        assert url == "https://ghp_abcdef123456@github.com/alice/api-service.git"
+        assert url == "https://git:ghp_abcdef123456@github.com/alice/api-service.git"
 
     def test_https_github_url_without_dot_git_suffix(self):
         from delulu_sandbox_modal.repo_provisioner import _build_push_url_with_pat
@@ -158,17 +154,41 @@ class TestBuildPushUrlWithPat:
             "https://github.com/alice/api-service",
             "ghp_abcdef123456",
         )
-        assert url == "https://ghp_abcdef123456@github.com/alice/api-service"
+        assert url == "https://git:ghp_abcdef123456@github.com/alice/api-service"
 
-    def test_no_username_prefix_in_url(self):
-        """Regression guard for the x-access-token mistake.
+    def test_pat_in_password_not_username_field(self):
+        """Regression guard — PR #58's mistake was putting the PAT alone in userinfo.
 
-        The bug that motivated this helper shape was using
-        ``x-access-token:<pat>@...`` as the userinfo, which
-        GitHub rejects with a misleading
-        "password authentication not supported" error. The
-        resulting URL must NOT contain any ``:`` in the
-        userinfo component — the token is the whole userinfo.
+        GitHub rejected token-only userinfo (``<pat>@github.com``)
+        because it wants the PAT in the password field. Git then
+        tried to read a password interactively and failed with
+        "could not read Password: No such device or address."
+
+        The userinfo must contain a ``:`` splitting a non-empty
+        username from the PAT, and the PAT must be AFTER the
+        colon (the password field).
+        """
+        from delulu_sandbox_modal.repo_provisioner import _build_push_url_with_pat
+
+        token = "ghp_abcdef"
+        url = _build_push_url_with_pat("https://github.com/alice/api-service", token)
+        # Extract the userinfo component
+        assert "://" in url and "@" in url
+        userinfo = url.split("://", 1)[1].split("@", 1)[0]
+        # Must have a colon splitting username:password
+        assert ":" in userinfo, f"userinfo must be 'user:pat' form, got {userinfo!r}"
+        username, _, password = userinfo.partition(":")
+        assert username, "username field must be non-empty"
+        assert password == token, f"PAT must be in password field, not username; got {userinfo!r}"
+
+    def test_no_xaccesstoken_regression(self):
+        """Regression guard — PR #56's mistake was ``x-access-token:<pat>``.
+
+        The ``x-access-token`` username is for GitHub App installation
+        tokens, not Personal Access Tokens. GitHub's auth layer routes
+        it to the App-token handler, which rejects PATs with a
+        misleading "password authentication not supported" error. This
+        test fails loudly if anyone ever re-adds that username.
         """
         from delulu_sandbox_modal.repo_provisioner import _build_push_url_with_pat
 
@@ -176,14 +196,6 @@ class TestBuildPushUrlWithPat:
             "https://github.com/alice/api-service",
             "ghp_abcdef",
         )
-        # Extract the userinfo component: everything between "://" and the next "@"
-        assert "://" in url and "@" in url
-        userinfo = url.split("://", 1)[1].split("@", 1)[0]
-        assert ":" not in userinfo, (
-            f"userinfo must be token-only (no ':' split), got {userinfo!r} — "
-            "this is the x-access-token regression guard"
-        )
-        assert userinfo == "ghp_abcdef"
         assert "x-access-token" not in url
 
     def test_fine_grained_pat_format_roundtrips(self):
@@ -192,7 +204,7 @@ class TestBuildPushUrlWithPat:
 
         token = "github_pat_11ABCDEFG_xyz123"
         url = _build_push_url_with_pat("https://github.com/alice/api-service", token)
-        assert f"{token}@github.com" in url
+        assert f":{token}@github.com" in url
 
     def test_non_default_port_preserved(self):
         from delulu_sandbox_modal.repo_provisioner import _build_push_url_with_pat
@@ -201,7 +213,7 @@ class TestBuildPushUrlWithPat:
             "https://github.example.com:8443/alice/api-service.git",
             "ghp_abcdef",
         )
-        assert "ghp_abcdef@github.example.com:8443" in url
+        assert "git:ghp_abcdef@github.example.com:8443" in url
 
     def test_ssh_url_rejected(self):
         """v1 only supports HTTPS remotes; SSH urls have no place for a PAT."""


### PR DESCRIPTION
## Summary
PR #58 was the third wrong guess at the PAT-in-URL format. PR #58 put the token as the full userinfo (\`https://<pat>@github.com/...\`), which git interpreted as username-only. GitHub rejected the empty password and git fell through to the interactive password prompt:

\`\`\`
fatal: could not read Password for 'https://***PAT***@github.com': No such device or address
\`\`\`

GitHub's auth flow for HTTPS with a PAT expects:

\`\`\`
Username: YOUR-USERNAME
Password: YOUR-PERSONAL-ACCESS-TOKEN
\`\`\`

**The PAT goes in the password field.** The username can be any non-empty string — GitHub ignores it and looks up the authenticated identity from the PAT. Confirmed via GitHub's own [managing personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) docs.

## Fix
Use \`git:<pat>@host\` as the URL form. \`git\` is an innocuous placeholder:
- **Non-empty** — required by HTTP Basic auth
- **Doesn't trigger special routing** on GitHub's auth layer (\`x-access-token\` and \`oauth2\` are reserved for different flows)
- **Doesn't need the user's GitHub handle** in the sandbox env

Added a module constant \`_PAT_URL_USERNAME = \"git\"\` with a prominent comment explaining \"do NOT use x-access-token\" so future refactors don't repeat PR #56's mistake.

## The full PAT auth saga (for the next person)

| Attempt | Approach | Why it failed |
|---|---|---|
| PR #56 v1 | \`-c http.extraheader=Authorization: Basic <b64(x-access-token:pat)>\` | git fell through to interactive credential prompt |
| PR #56 v2 | \`x-access-token:<pat>@github.com\` in URL | \`x-access-token\` is for GitHub Apps, not PATs → GitHub routes to wrong auth handler → misleading \"password auth not supported\" error |
| PR #58 | \`<pat>@github.com\` (token-only userinfo) | GitHub rejected empty password field → git prompted interactively → \"could not read Password\" |
| **#59** (this) | \`git:<pat>@github.com\` | Should finally work — matches the documented form |

Each attempt's root cause is now spelled out in the \`_build_push_url_with_pat\` docstring so the next person who touches this code has the full context.

## Tests
- Updated assertions for the new \`git:<pat>@...\` form (5 tests)
- Kept \`test_no_xaccesstoken_regression\` from PR #58 — guards against #56's mistake
- Added \`test_pat_in_password_not_username_field\` — guards against #58's mistake; asserts the userinfo contains a colon AND that the PAT is in the password field (after the colon), not the username field (before it)
- **Net: 53 passed** (was 52, +1 new guard), ruff format + check clean

## Test plan
- [x] \`ruff format --check . && ruff check . && pytest\` → 53 passed
- [ ] Merge this → CD redeploys sandbox via \`delulu-sandbox-modal-deploy\`
- [ ] Re-run \`/commit\` in the failing thread. There are now **three queued local commits** on the \`claude/<thread-id>\` branch from the prior failed push attempts (d452461, 119b2ed, 3df28ab). The new successful push will carry all three to the remote in one shot.
- [ ] Click the GitHub compare URL → expect to see the accumulated README changes across all three commits
- [ ] Separately: try \`@delulu please commit and open a PR\` via the natural-language path. That exercises PR #57's gh CLI installation + GH_TOKEN env plumbing, which is a completely different codepath from this PR. Both should work end-to-end now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)