### PR TITLE
fix: conventional branch names, unpushed commit retry, remove reasoning spoiler

### DIFF
--- a/apps/delulu_discord/src/delulu_discord/streaming.py
+++ b/apps/delulu_discord/src/delulu_discord/streaming.py
@@ -48,8 +48,8 @@ def _render(
     - Empty transcript and no ``done_footer`` → initial
       "thinking..." placeholder. The repo subtitle is appended below
       the placeholder if a repo is bound.
-    - Latest ``thinking`` block collapses into one spoiler line at the
-      top (``||🧠 Reasoning: …||``).
+    - Latest ``thinking`` block renders as a plain-text line at the
+      top (``🧠 <preview>``). No spoiler tags — always visible.
     - If ``repo_url`` is set, an active-repo subtitle line
       (``📁 owner/repo@ref``) is rendered as the second line, right
       below the thinking/reasoning header. Omitted entirely when
@@ -142,7 +142,7 @@ def _render_header(transcript: list[dict[str, Any]]) -> str:
     preview = (
         latest[:THINKING_PREVIEW_LIMIT] + "…" if len(latest) > THINKING_PREVIEW_LIMIT else latest
     )
-    return f"||🧠 Reasoning: {preview}||"
+    return f"🧠 {preview}"
 
 
 def _render_tool_lines(transcript: list[dict[str, Any]]) -> list[str]:

--- a/apps/delulu_discord/tests/test_streaming.py
+++ b/apps/delulu_discord/tests/test_streaming.py
@@ -62,7 +62,7 @@ def test_text_event_appends_writing_marker() -> None:
     assert rendered.splitlines()[-1].startswith("✍️")
 
 
-def test_thinking_block_replaces_default_header_with_spoiler() -> None:
+def test_thinking_block_replaces_default_header() -> None:
     rendered = _render(
         [
             {"type": "thinking", "text": "considering the approach"},
@@ -70,8 +70,7 @@ def test_thinking_block_replaces_default_header_with_spoiler() -> None:
         ]
     )
     lines = rendered.splitlines()
-    assert lines[0].startswith("||🧠 Reasoning:")
-    assert lines[0].endswith("||")
+    assert lines[0].startswith("🧠")
     assert "considering the approach" in lines[0]
     # Default placeholder should NOT appear when thinking is present
     assert INITIAL_PLACEHOLDER not in rendered
@@ -91,9 +90,9 @@ def test_multiple_thinking_blocks_keeps_latest_only() -> None:
 def test_long_thinking_preview_is_truncated() -> None:
     long_thought = "a" * 500
     rendered = _render([{"type": "thinking", "text": long_thought}])
-    assert "…||" in rendered
-    # Spoiler wrapper + emoji + "Reasoning: " + up to 150 chars of thought + "…"
-    assert len(rendered) < 250
+    assert "…" in rendered
+    # Emoji + up to 150 chars of thought + "…"
+    assert len(rendered) < 200
 
 
 def test_fifo_matching_of_same_tool_called_twice() -> None:
@@ -129,7 +128,7 @@ def test_full_progression_matches_plan_example() -> None:
     ]
     rendered = _render(transcript)
     lines = rendered.splitlines()
-    assert lines[0].startswith("||🧠 Reasoning:")
+    assert lines[0].startswith("🧠")
     assert "🔧 Read `src/app.py` ✓" in rendered
     assert "🔧 Read `src/handlers.py` ✓" in rendered
     # Grep is still pending — no marker
@@ -184,7 +183,7 @@ def test_render_with_done_footer_drops_writing_marker() -> None:
     assert rendered.splitlines()[-1] == "✅ Done • 1 tools • 0.5s"
 
 
-def test_render_with_done_footer_preserves_thinking_spoiler() -> None:
+def test_render_with_done_footer_preserves_thinking_header() -> None:
     transcript = [
         {"type": "thinking", "text": "thinking about the approach"},
         _tool_use("Read", "`x.py`"),
@@ -192,7 +191,7 @@ def test_render_with_done_footer_preserves_thinking_spoiler() -> None:
     ]
     rendered = _render(transcript, done_footer="✅ Done • 1 tools • 2.0s")
     lines = rendered.splitlines()
-    assert lines[0].startswith("||🧠 Reasoning:")
+    assert lines[0].startswith("🧠")
     assert "thinking about the approach" in lines[0]
     assert lines[-1] == "✅ Done • 1 tools • 2.0s"
 
@@ -328,7 +327,7 @@ def test_render_with_repo_adds_subtitle_under_header() -> None:
     assert "🔧 Read `x.py`" in rendered
 
 
-def test_render_with_repo_under_thinking_spoiler() -> None:
+def test_render_with_repo_under_thinking_header() -> None:
     """When reasoning is present the spoiler header is line 0; repo line is line 1."""
     rendered = _render(
         [
@@ -339,7 +338,7 @@ def test_render_with_repo_under_thinking_spoiler() -> None:
         ref="main",
     )
     lines = rendered.splitlines()
-    assert lines[0].startswith("||🧠 Reasoning:")
+    assert lines[0].startswith("🧠")
     assert lines[1] == "📁 alice/api-service@main"
 
 

--- a/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/repo_provisioner.py
+++ b/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/repo_provisioner.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -326,6 +327,63 @@ def _elapsed_ms(start: float) -> int:
     return int((time.monotonic() - start) * 1000)
 
 
+def _resolve_branch_name(workspace_path: str, thread_id: int, message: str) -> str:
+    """Return the branch name for this thread, creating or reusing as needed.
+
+    First /commit: derives a conventional-commit-style branch name
+    from the commit message and caches it in ``.commit-branch`` on
+    the workspace. Subsequent /commits reuse the cached name so the
+    branch is stable even if the message changes.
+
+    Examples:
+        ``feat: add rate limiting`` → ``feat/add-rate-limiting-494242``
+        ``fix(auth): resolve timeout`` → ``fix/resolve-timeout-494242``
+        ``just update the readme`` → ``claude/update-the-readme-494242``
+    """
+    marker_path = os.path.join(workspace_path, COMMIT_BRANCH_MARKER)
+    if os.path.isfile(marker_path):
+        try:
+            with open(marker_path) as f:
+                cached = f.read().strip()
+            if cached:
+                return cached
+        except OSError:
+            pass
+
+    branch = _make_branch_name(thread_id, message)
+    with open(marker_path, "w") as f:
+        f.write(branch)
+    return branch
+
+
+def _make_branch_name(thread_id: int, message: str) -> str:
+    """Build a branch name like ``feat/add-rate-limiting-494242``.
+
+    Parses the commit message for a conventional-commit type prefix
+    (``feat:``, ``fix:``, etc.). If found, uses that as the branch
+    prefix. Otherwise falls back to ``claude/``. The subject is
+    slugified (lowercased, non-alphanum replaced with dashes,
+    trimmed to 50 chars). A short suffix from the thread_id ensures
+    uniqueness across threads with similar messages.
+    """
+    # Parse "type: subject" or "type(scope): subject"
+    match = re.match(
+        r"^(" + "|".join(CONVENTIONAL_TYPES) + r")(?:\([^)]*\))?:\s*(.+)",
+        message,
+        re.IGNORECASE,
+    )
+    if match:
+        type_prefix = match.group(1).lower()
+        subject = match.group(2)
+    else:
+        type_prefix = COMMIT_BRANCH_DEFAULT_PREFIX
+        subject = message
+
+    slug = re.sub(r"[^a-z0-9]+", "-", subject.lower()).strip("-")[:50]
+    short_id = str(thread_id)[-6:]
+    return f"{type_prefix}/{slug}-{short_id}"
+
+
 # ─────────────────────────────────────────────────────────────────
 # Commit-back: stage, commit, and push pending changes from a
 # per-thread workspace to a `claude/<thread_id>` branch on the
@@ -344,12 +402,22 @@ def _elapsed_ms(start: float) -> int:
 # token as a parameter so the function is testable without env
 # munging and the auth check stays at the boundary.
 
-# The branch name we always commit to. One branch per thread, so a
-# user can iterate on the same conceptual "task" across multiple
-# /commit calls and have them stack on the same branch — and the
-# remote PR (if they open one) shows the full history of the
-# thread's changes.
-COMMIT_BRANCH_PREFIX = "claude/"
+# Default branch prefix when the commit message doesn't have a
+# conventional-commit type prefix. If the message starts with
+# "feat:", "fix:", etc., the branch uses that type as the prefix
+# instead. One branch per thread — multiple /commit calls stack
+# on the same branch.
+COMMIT_BRANCH_DEFAULT_PREFIX = "claude"
+
+# Marker file written to the workspace after the first /commit to
+# lock the branch name. Subsequent /commits reuse it so the branch
+# name is stable even if the commit message changes.
+COMMIT_BRANCH_MARKER = ".commit-branch"
+
+# Conventional commit types we recognize for branch naming.
+CONVENTIONAL_TYPES = frozenset(
+    {"feat", "fix", "docs", "refactor", "test", "chore", "ci", "build", "perf", "style"}
+)
 
 # The git author identity for bot-made commits. The ACTUAL pusher
 # (visible in GitHub's UI as "pushed by") is whoever owns the PAT
@@ -425,39 +493,50 @@ def commit_workspace_changes(
     status_result = _run_git(
         ["-C", workspace_path, "status", "--porcelain"],
     )
-    if not status_result.stdout.strip():
-        return CommitResult(status="no_changes")
+    has_uncommitted = bool(status_result.stdout.strip())
 
-    branch = f"{COMMIT_BRANCH_PREFIX}{thread_id}"
+    branch = _resolve_branch_name(workspace_path, thread_id, message)
 
-    # Check out the thread's branch. ``-B`` creates if missing OR
-    # resets to the current HEAD if existing — but we want to PRESERVE
-    # any prior commits on this branch from earlier /commit calls.
-    # So: try `git checkout` first; if that fails (branch doesn't
-    # exist), `git checkout -b` to create.
-    try:
+    if has_uncommitted:
+        # Check out the thread's branch. Try switching first; if
+        # the branch doesn't exist yet, create it.
+        try:
+            _run_git(["-C", workspace_path, "checkout", branch])
+        except RuntimeError:
+            _run_git(["-C", workspace_path, "checkout", "-b", branch])
+
+        # Stage everything and commit with the bot's git identity.
+        # ``-c user.name=...`` is per-command, not persisted to config.
+        _run_git(["-C", workspace_path, "add", "-A"])
+        _run_git(
+            [
+                "-c",
+                f"user.name={author_name}",
+                "-c",
+                f"user.email={author_email}",
+                "-C",
+                workspace_path,
+                "commit",
+                "-m",
+                message,
+            ]
+        )
+    else:
+        # No uncommitted changes. But there might be previously
+        # committed-but-unpushed changes from a prior /commit
+        # attempt that failed at the push step. Check if the
+        # branch exists locally — if it does, fall through to
+        # the push step which will push the existing commits.
+        branch_check = _run_git(
+            ["-C", workspace_path, "rev-parse", "--verify", branch],
+            check=False,
+        )
+        if branch_check.returncode != 0:
+            return CommitResult(status="no_changes")
+        # Branch exists — make sure we're on it for the push.
         _run_git(["-C", workspace_path, "checkout", branch])
-    except RuntimeError:
-        _run_git(["-C", workspace_path, "checkout", "-b", branch])
 
-    # Stage everything and commit with the bot's git identity.
-    # ``-c user.name=...`` is per-command, not persisted to config.
-    _run_git(["-C", workspace_path, "add", "-A"])
-    _run_git(
-        [
-            "-c",
-            f"user.name={author_name}",
-            "-c",
-            f"user.email={author_email}",
-            "-C",
-            workspace_path,
-            "commit",
-            "-m",
-            message,
-        ]
-    )
-
-    # Capture the new commit SHA for the response.
+    # Capture the current HEAD SHA (new commit or existing unpushed).
     sha_result = _run_git(["-C", workspace_path, "rev-parse", "HEAD"])
     commit_sha = sha_result.stdout.strip()
 

--- a/apps/delulu_sandbox_modal/tests/test_repo_provisioner.py
+++ b/apps/delulu_sandbox_modal/tests/test_repo_provisioner.py
@@ -14,6 +14,8 @@ directory. Cheap insurance.
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from delulu_sandbox_modal.repo_provisioner import _parse_repo_url
@@ -271,6 +273,97 @@ class TestScrubPat:
         from delulu_sandbox_modal.repo_provisioner import _scrub_pat
 
         assert _scrub_pat("no secrets here", "ghp_xxx") == "no secrets here"
+
+
+class TestMakeBranchName:
+    """Branch naming from conventional-commit messages."""
+
+    def test_feat_prefix(self):
+        from delulu_sandbox_modal.repo_provisioner import _make_branch_name
+
+        assert (
+            _make_branch_name(1234567890, "feat: add rate limiting")
+            == "feat/add-rate-limiting-567890"
+        )
+
+    def test_fix_prefix(self):
+        from delulu_sandbox_modal.repo_provisioner import _make_branch_name
+
+        assert (
+            _make_branch_name(1234567890, "fix: resolve timeout bug")
+            == "fix/resolve-timeout-bug-567890"
+        )
+
+    def test_docs_prefix(self):
+        from delulu_sandbox_modal.repo_provisioner import _make_branch_name
+
+        assert _make_branch_name(42, "docs: update README") == "docs/update-readme-42"
+
+    def test_scoped_type(self):
+        from delulu_sandbox_modal.repo_provisioner import _make_branch_name
+
+        result = _make_branch_name(99, "fix(auth): resolve timeout")
+        assert result.startswith("fix/")
+        assert "resolve-timeout" in result
+
+    def test_no_type_prefix_falls_back_to_claude(self):
+        from delulu_sandbox_modal.repo_provisioner import _make_branch_name
+
+        result = _make_branch_name(42, "just update the readme")
+        assert result.startswith("claude/")
+        assert "update-the-readme" in result
+
+    def test_long_subject_truncated(self):
+        from delulu_sandbox_modal.repo_provisioner import _make_branch_name
+
+        long_msg = "feat: " + "a" * 200
+        result = _make_branch_name(42, long_msg)
+        slug_part = result.split("/", 1)[1].rsplit("-", 1)[0]
+        assert len(slug_part) <= 50
+
+    def test_special_chars_slugified(self):
+        from delulu_sandbox_modal.repo_provisioner import _make_branch_name
+
+        result = _make_branch_name(42, "feat: add rate-limiting & auth!")
+        assert result.startswith("feat/")
+        assert "&" not in result
+        assert "!" not in result
+
+    def test_case_insensitive_type(self):
+        from delulu_sandbox_modal.repo_provisioner import _make_branch_name
+
+        result = _make_branch_name(42, "FEAT: add something")
+        assert result.startswith("feat/")
+
+    def test_thread_id_suffix_is_last_6_digits(self):
+        from delulu_sandbox_modal.repo_provisioner import _make_branch_name
+
+        result = _make_branch_name(1494242875117011085, "feat: test")
+        assert result.endswith("-011085")
+
+
+class TestResolveBranchName:
+    """Branch name caching via .commit-branch marker."""
+
+    def test_first_call_creates_marker(self, tmp_path):
+        from delulu_sandbox_modal.repo_provisioner import _resolve_branch_name
+
+        workspace = str(tmp_path / "ws")
+        os.makedirs(workspace)
+        branch = _resolve_branch_name(workspace, 42, "feat: add X")
+        assert branch.startswith("feat/")
+        marker = tmp_path / "ws" / ".commit-branch"
+        assert marker.exists()
+        assert marker.read_text().strip() == branch
+
+    def test_second_call_reuses_cached(self, tmp_path):
+        from delulu_sandbox_modal.repo_provisioner import _resolve_branch_name
+
+        workspace = str(tmp_path / "ws")
+        os.makedirs(workspace)
+        first = _resolve_branch_name(workspace, 42, "feat: add X")
+        second = _resolve_branch_name(workspace, 42, "fix: different message")
+        assert first == second
 
 
 class TestCommitWorkspaceChanges:


### PR DESCRIPTION
## Summary
Three QoL fixes from the v1 smoke test in one PR.

### 1. Branch names follow conventional commits
\`/commit\` now derives the branch name from the commit message type prefix:

| Message | Branch |
|---|---|
| \`feat: add rate limiting\` | \`feat/add-rate-limiting-494242\` |
| \`fix(auth): resolve timeout\` | \`fix/resolve-timeout-494242\` |
| \`docs: update README\` | \`docs/update-readme-494242\` |
| \`just update readme\` (no prefix) | \`claude/update-readme-494242\` |

The short suffix (last 6 digits of thread_id) ensures uniqueness across threads. First \`/commit\` in a thread writes a \`.commit-branch\` marker file to the workspace; subsequent \`/commit\`s reuse it so the branch name is stable even if the commit message changes.

### 2. \`/commit\` retries unpushed commits
When \`git status --porcelain\` is clean but the thread's branch exists locally (from a prior \`/commit\` whose push failed), skip the commit step and fall through to the push step. Previously this returned \"nothing to commit\" and the user had to start a fresh thread to retry.

### 3. Removed reasoning spoiler tags
The \`||🧠 Reasoning: ...||}\` Discord spoiler on the thinking line rendered as a grayed-out click-to-reveal block — annoying for a single line. Now renders as plain visible text: \`🧠 <preview>\`.

## Tests
- **64 sandbox tests** (53 prior + 11 new for branch naming/caching)
- **36 bot tests** (updated assertions for non-spoiler format)
- **100 total**, ruff format + check clean on both apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)