### PR TITLE
fix(sandbox): authenticate worktree add for private repos

### DIFF
--- a/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/repo_provisioner.py
+++ b/apps/delulu_sandbox_modal/src/delulu_sandbox_modal/repo_provisioner.py
@@ -131,7 +131,7 @@ def provision_workspace(
 
     # Create (or replace) the per-thread worktree.
     worktree_start = time.monotonic()
-    _ensure_worktree(bare_path, workspace_path, ref)
+    _ensure_worktree(bare_path, workspace_path, ref, github_token=github_token)
     timings.worktree_ms = _elapsed_ms(worktree_start)
 
     # Record the marker so the next provision on the same thread
@@ -254,7 +254,13 @@ def _fetch_bare(bare_path: str, ref: str, *, github_token: str | None = None) ->
     )
 
 
-def _ensure_worktree(bare_path: str, workspace_path: str, ref: str) -> None:
+def _ensure_worktree(
+    bare_path: str,
+    workspace_path: str,
+    ref: str,
+    *,
+    github_token: str | None = None,
+) -> None:
     """Create or reuse a worktree at ``workspace_path`` checked out at ``ref``.
 
     Handles three cases:
@@ -268,6 +274,14 @@ def _ensure_worktree(bare_path: str, workspace_path: str, ref: str) -> None:
 
     Prunes stale worktree registrations first so the bare cache's
     ``worktrees/`` dir doesn't accumulate dead entries.
+
+    ``github_token`` authenticates the lazy blob fetches that
+    ``git checkout`` and ``git worktree add`` trigger against the
+    bare cache's promisor remote (origin) — without it, private-repo
+    worktrees fail with "could not read Username for
+    'https://github.com'" the moment a missing blob has to be
+    materialized. ``git worktree prune`` is local-only and doesn't
+    need the token.
     """
     # Prune any dead worktree registrations cheaply.
     _run_git(["-C", bare_path, "worktree", "prune"], check=False)
@@ -276,7 +290,7 @@ def _ensure_worktree(bare_path: str, workspace_path: str, ref: str) -> None:
         git_marker = os.path.join(workspace_path, ".git")
         if os.path.exists(git_marker):
             # Valid worktree — just checkout the ref.
-            _run_git(["-C", workspace_path, "checkout", ref])
+            _run_git(["-C", workspace_path, "checkout", ref], github_token=github_token)
             return
         # Exists but not a worktree. Wipe and recreate below.
         shutil.rmtree(workspace_path)
@@ -291,7 +305,8 @@ def _ensure_worktree(bare_path: str, workspace_path: str, ref: str) -> None:
             "--force",
             workspace_path,
             ref,
-        ]
+        ],
+        github_token=github_token,
     )
 
 

--- a/apps/delulu_sandbox_modal/tests/test_repo_provisioner.py
+++ b/apps/delulu_sandbox_modal/tests/test_repo_provisioner.py
@@ -539,3 +539,92 @@ class TestValidateRepoAccess:
         result = repo_provisioner.validate_repo_access("not-a-url")
         assert result.status == repo_provisioner.ACCESS_ERROR
         assert result.error
+
+
+class TestEnsureWorktreeAuth:
+    """``_ensure_worktree`` must thread ``github_token`` to its
+    ``_run_git`` calls.
+
+    Without it, ``git checkout <ref>`` and ``git worktree add ... HEAD``
+    against a ``--filter=blob:none`` bare cache lazy-fetch missing
+    blobs from the promisor remote (origin); on a private repo that
+    fetch dies with "could not read Username for 'https://github.com'"
+    the moment a missing blob has to be materialized — the exact
+    failure the user reported in the original traceback. The clone
+    and fetch already had auth (PR #72); only this last hop was
+    missed.
+    """
+
+    def test_passes_token_to_worktree_add(self, tmp_path, monkeypatch):
+        from delulu_sandbox_modal import repo_provisioner
+
+        calls: list[tuple[list[str], dict]] = []
+
+        def fake_run_git(args, *, check=True, github_token=None):
+            calls.append((list(args), {"github_token": github_token}))
+
+        monkeypatch.setattr(repo_provisioner, "_run_git", fake_run_git)
+
+        # Don't pre-create either dir — the "workspace exists?" check
+        # is False, so we hit the `worktree add` branch.
+        bare_path = str(tmp_path / "bare.git")
+        workspace_path = str(tmp_path / "ws")
+
+        repo_provisioner._ensure_worktree(
+            bare_path,
+            workspace_path,
+            "HEAD",
+            github_token="ghp_test",
+        )
+
+        worktree_add = next(c for c in calls if "add" in c[0])
+        assert worktree_add[1]["github_token"] == "ghp_test"
+
+    def test_passes_token_to_checkout(self, tmp_path, monkeypatch):
+        # Warm path — existing worktree with a .git marker → just
+        # `git checkout <ref>`. Same lazy-fetch hazard.
+        from delulu_sandbox_modal import repo_provisioner
+
+        calls: list[tuple[list[str], dict]] = []
+
+        def fake_run_git(args, *, check=True, github_token=None):
+            calls.append((list(args), {"github_token": github_token}))
+
+        monkeypatch.setattr(repo_provisioner, "_run_git", fake_run_git)
+
+        workspace_path = str(tmp_path / "ws")
+        os.makedirs(workspace_path)
+        # The .git marker file is what triggers the warm path.
+        with open(os.path.join(workspace_path, ".git"), "w") as f:
+            f.write("gitdir: ../bare.git/worktrees/ws\n")
+
+        repo_provisioner._ensure_worktree(
+            str(tmp_path / "bare.git"),
+            workspace_path,
+            "HEAD",
+            github_token="ghp_test",
+        )
+
+        checkout = next(c for c in calls if "checkout" in c[0])
+        assert checkout[1]["github_token"] == "ghp_test"
+
+    def test_no_token_passes_none(self, tmp_path, monkeypatch):
+        # Public-repo path stays unauthenticated — explicit None,
+        # not the literal string "None" or any default sentinel.
+        from delulu_sandbox_modal import repo_provisioner
+
+        calls: list[tuple[list[str], dict]] = []
+
+        def fake_run_git(args, *, check=True, github_token=None):
+            calls.append((list(args), {"github_token": github_token}))
+
+        monkeypatch.setattr(repo_provisioner, "_run_git", fake_run_git)
+
+        repo_provisioner._ensure_worktree(
+            str(tmp_path / "bare.git"),
+            str(tmp_path / "ws"),
+            "HEAD",
+        )
+
+        worktree_add = next(c for c in calls if "add" in c[0])
+        assert worktree_add[1]["github_token"] is None


### PR DESCRIPTION
## Summary

Follow-up to #72. PR #72 added `github_token` plumbing to `_clone_bare`, `_fetch_bare`, and `_run_git` but missed `_ensure_worktree` — which is the exact code path that hit the failure reported in Discord:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: could not fetch <sha> from promisor remote
```

Both `git checkout <ref>` (warm worktree) and `git worktree add ... <ref>` (cold worktree) lazy-fetch missing blobs from the bare cache's promisor remote (origin). With `--filter=blob:none` clones, that fetch happens on every checkout — and on a private repo it needs auth.

## Fix

- Add `github_token` kwarg to `_ensure_worktree`.
- Pass it to the two `_run_git` calls that hit the network: `git checkout <ref>` and `git worktree add ... <ref>`.
- `git worktree prune` is local-only and stays unauthenticated.

Three-line change in `repo_provisioner.py` (signature + two call sites) plus the helper-side `_ensure_worktree(...)` invocation in `provision_workspace`.

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pytest` — 75 passed (3 new tests in `TestEnsureWorktreeAuth` for cold/warm/no-token paths)
- [ ] Deploy to Modal and re-run \`@delulu what pr do we have open for this repo\` against the private repo from the original report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)