### PR TITLE
fix(delulu): persist SessionManager to SQLite on a Docker volume

### DIFF
--- a/apps/delulu_discord/Dockerfile
+++ b/apps/delulu_discord/Dockerfile
@@ -13,5 +13,12 @@ COPY pyproject.toml uv.lock .python-version ./
 COPY src/ src/
 RUN uv pip install --system .
 
+# Persistent state directory. The Makefile's ``restart`` target
+# mounts the named Docker volume ``disco-data`` here so the bot's
+# SQLite session DB (``/data/sessions.db``) survives ``docker rm``.
+# Creating the dir at build time means the bot starts cleanly even
+# on the first deploy before the volume has any contents.
+RUN mkdir -p /data
+
 # The bot is lightweight — ~50MB RAM
 CMD ["python", "-m", "delulu_discord.main"]

--- a/apps/delulu_discord/Makefile
+++ b/apps/delulu_discord/Makefile
@@ -5,6 +5,11 @@ BOT_NAME   ?= disco
 IMAGE      ?= delulu-discord
 ENV_FILE   ?= /root/disco.env
 MODAL_TOML ?= /root/.modal.toml
+# Named Docker volume for the bot's persistent state (currently the
+# SQLite session DB at /data/sessions.db inside the container).
+# Survives `docker rm` so /setrepo bindings + thread sessions stick
+# across deploys. Created automatically by Docker on first run.
+DATA_VOLUME ?= disco-data
 
 help:
 	@echo "Targets (VPS deploy):"
@@ -51,6 +56,7 @@ restart:
 	  --restart=unless-stopped \
 	  --env-file $(ENV_FILE) \
 	  -v $(MODAL_TOML):/root/.modal.toml:ro \
+	  -v $(DATA_VOLUME):/data \
 	  $(IMAGE)
 
 deploy: image restart

--- a/apps/delulu_discord/pyproject.toml
+++ b/apps/delulu_discord/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Discord bot that dispatches Claude Code tasks to Modal sandboxes"
 requires-python = ">=3.14"
 dependencies = [
+    "aiosqlite>=0.20",
     "discord.py>=2.4,<3",
     "modal>=1.0",
     "pydantic>=2.0,<3",

--- a/apps/delulu_discord/src/delulu_discord/commands.py
+++ b/apps/delulu_discord/src/delulu_discord/commands.py
@@ -342,7 +342,7 @@ def register_slash_commands(
         # The session must exist (so we know there's a workspace
         # this thread is bound to) and must have a repo binding
         # (so there's something meaningful to commit and push).
-        session = session_manager.get_session(interaction.channel.id)
+        session = await session_manager.get_session(interaction.channel.id)
         if session is None:
             await interaction.response.send_message(
                 "❌ No active session in this thread. Mention `@claude` first to create one.",

--- a/apps/delulu_discord/src/delulu_discord/handlers.py
+++ b/apps/delulu_discord/src/delulu_discord/handlers.py
@@ -73,7 +73,7 @@ class MessageHandler:
             else:
                 is_private = False
 
-        session = self.sessions.create_session(
+        session = await self.sessions.create_session(
             thread.id,
             repo_url=repo_url,
             ref=ref,
@@ -101,7 +101,7 @@ class MessageHandler:
         thread = message.channel
         assert isinstance(thread, discord.Thread)
 
-        session, is_new = self.sessions.get_or_create(thread.id)
+        session, is_new = await self.sessions.get_or_create(thread.id)
         resume = not is_new
         attachments = await _download_attachments(message)
 

--- a/apps/delulu_discord/src/delulu_discord/main.py
+++ b/apps/delulu_discord/src/delulu_discord/main.py
@@ -41,7 +41,13 @@ def create_bot(settings: Settings) -> discord.Client:
     tree = app_commands.CommandTree(client)
 
     # ── Wire up components ───────────────────────────────────
-    session_manager = SessionManager(ttl_seconds=settings.session_ttl_seconds)
+    # Persistent SQLite-backed session store. Caller (``main()``)
+    # awaits ``session_manager.connect()`` before ``client.start``
+    # so the schema is in place by the time the first message lands.
+    session_manager = SessionManager(
+        db_path=settings.session_db_path,
+        ttl_seconds=settings.session_ttl_seconds,
+    )
     dispatcher = SandboxDispatcher(settings=settings)
     # Modal-Dict-backed channel→(repo_url, ref) binding store. Set
     # via /setrepo, looked up at @claude dispatch time.
@@ -65,6 +71,12 @@ def create_bot(settings: Settings) -> discord.Client:
         session_manager=session_manager,
         dispatcher=dispatcher,
     )
+
+    # Stash on the client so ``main()._run`` can reach it for
+    # ``connect()`` / ``close()`` without changing this function's
+    # return signature. discord.Client doesn't reserve underscore
+    # attributes, so this is safe.
+    client._session_manager = session_manager  # type: ignore[attr-defined]
 
     # ── Event handlers ───────────────────────────────────────
     @client.event
@@ -101,10 +113,14 @@ def create_bot(settings: Settings) -> discord.Client:
         # Thread reply: auto-continue if this thread is already ours, otherwise
         # require an explicit @-mention to pull us into the conversation.
         if isinstance(channel, discord.Thread):
-            owns_thread = (
-                channel.owner_id == bot_user.id
-                or session_manager.get_session(channel.id) is not None
-            )
+            # Check ``channel.owner_id`` first — purely in-memory and
+            # avoids the DB hit on the common case (bot-created
+            # threads). Only fall through to ``get_session`` when we
+            # might own the thread but didn't create it ourselves
+            # (e.g. session inherited a thread created by the user).
+            owns_thread = channel.owner_id == bot_user.id
+            if not owns_thread:
+                owns_thread = await session_manager.get_session(channel.id) is not None
             if not (owns_thread or bot_mentioned):
                 return
             prompt = _strip_mention(message.content, bot_user.id)
@@ -125,6 +141,28 @@ def create_bot(settings: Settings) -> discord.Client:
     return client
 
 
+async def _run(settings: Settings) -> None:
+    """Bring up SessionManager, start the Discord client, tear down cleanly.
+
+    Split out so ``client.start(...)`` runs in the same event loop as
+    ``await session_manager.connect()`` and ``await
+    session_manager.close()``. The ``finally`` runs on KeyboardInterrupt
+    and on Discord-side exceptions alike, so the SQLite WAL gets
+    checkpointed and the connection released even on hard restarts.
+    """
+    client = create_bot(settings)
+    # ``client._session_manager`` is set by ``create_bot`` for the
+    # lifecycle hooks here; pulling it back out keeps the wiring in
+    # one place. Plain attribute access on discord.Client is fine —
+    # the library doesn't reserve underscore-prefixed names.
+    session_manager: SessionManager = client._session_manager  # type: ignore[attr-defined]
+    await session_manager.connect()
+    try:
+        await client.start(settings.discord_bot_token)
+    finally:
+        await session_manager.close()
+
+
 def main() -> None:
     """Entrypoint for `delulu-discord` console script."""
     structlog.configure(
@@ -141,8 +179,7 @@ def main() -> None:
         logger.error("config.invalid", error=str(e))
         sys.exit(1)
 
-    client = create_bot(settings)
-    asyncio.run(client.start(settings.discord_bot_token))
+    asyncio.run(_run(settings))
 
 
 if __name__ == "__main__":

--- a/apps/delulu_discord/src/delulu_discord/session_manager.py
+++ b/apps/delulu_discord/src/delulu_discord/session_manager.py
@@ -1,14 +1,75 @@
-"""Maps Discord threads to Claude Code sessions with TTL expiry."""
+"""SQLite-backed per-thread session store.
+
+Replaces the previous in-memory ``dict[int, Session]`` so per-thread
+state survives bot restarts. The deploy path on the VPS does
+``docker rm`` + ``docker run`` (see the ``restart`` target in
+``apps/delulu_discord/Makefile``); without persistence, every deploy
+silently wiped the ``repo_url`` / ``ref`` / ``is_private`` that
+``handle_channel_message`` had stitched onto each thread's session
+from ``RepoConfig``. Subsequent ``handle_thread_reply`` calls (which
+do *not* re-consult ``RepoConfig``) then fell through to the
+empty-workspace path, surfacing as "the bot forgot my /setrepo."
+
+Storage layout:
+
+- A SQLite file at ``Settings.session_db_path`` (defaults to
+  ``/data/sessions.db``, mounted from the ``disco-data`` named Docker
+  volume in the Makefile's ``restart`` target). Named volumes survive
+  ``docker rm``, which is what makes this fix work.
+- One row per Discord thread, keyed on ``thread_id`` (PK).
+- WAL journal mode for crash safety + concurrent reads.
+
+Concurrency model:
+
+- A single ``aiosqlite.Connection`` opened in ``connect()`` and
+  closed in ``close()``. aiosqlite owns one background thread per
+  connection and serializes every operation onto it; the bot is a
+  single-process asyncio app, so one connection is plenty and avoids
+  per-call thread-handoff cost on the hot path (every Discord
+  message hits this).
+- **One bot replica only.** WAL handles concurrent processes on the
+  same host file, but two droplets writing to the same file would
+  corrupt the DB — that's a Postgres-shaped problem if it ever comes
+  up.
+"""
 
 from __future__ import annotations
 
 import time
 import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 
+import aiosqlite
 import structlog
 
 logger = structlog.get_logger()
+
+# Bumped when the schema changes in a way that requires a migration.
+# Read on connect from ``schema_meta``; new columns can branch on it.
+SCHEMA_VERSION = "1"
+
+# Idempotent schema. ``CREATE TABLE IF NOT EXISTS`` makes connect()
+# safe to call against a fresh DB or an existing one. Index on
+# ``last_active_at`` makes a future janitor (DELETE WHERE
+# last_active_at < ?) cheap; not on the hot read path (PK lookups).
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS sessions (
+    thread_id      INTEGER PRIMARY KEY,
+    session_id     TEXT    NOT NULL,
+    repo_url       TEXT,
+    ref            TEXT    NOT NULL DEFAULT 'HEAD',
+    is_private     INTEGER NOT NULL DEFAULT 0,
+    created_at     REAL    NOT NULL,
+    last_active_at REAL    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_last_active
+    ON sessions(last_active_at);
+CREATE TABLE IF NOT EXISTS schema_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"""
 
 
 @dataclass
@@ -25,8 +86,8 @@ class Session:
     session creation time. Once a thread is started, its binding is
     grandfathered for the lifetime of the session — even if someone
     later ``/setrepo``s the channel to a different repo, in-flight
-    threads keep their original repo. This matches the PRD's
-    "thread binding is captured at thread creation" decision.
+    threads keep their original repo. With persistence, this
+    grandfathering also holds across bot restarts.
     """
 
     session_id: str
@@ -62,24 +123,83 @@ class Session:
     def is_expired(self, ttl_seconds: int) -> bool:
         return (time.time() - self.last_active_at) > ttl_seconds
 
-    def touch(self) -> None:
-        self.last_active_at = time.time()
-
 
 class SessionManager:
-    """Thread-to-session mapping with TTL-based expiry.
+    """SQLite-backed mapping of Discord thread → Claude Code session.
+
+    Caller MUST ``await connect()`` before any other method, and
+    SHOULD ``await close()`` at shutdown. ``connect`` is idempotent
+    (re-calling it is a no-op once connected); ``close`` is too.
+    Methods raise ``RuntimeError`` if used before ``connect``.
 
     Thread IDs are the primary key. When a thread's session expires,
-    we keep the workspace but start a fresh Claude Code session — the
-    workspace_path is deterministic per thread_id so this Just Works
+    the row stays so ``get_or_create`` can carry forward the prior
+    binding to the fresh session — same Discord thread, same repo,
+    fresh Claude Code session. The workspace_path is deterministic
+    per thread_id (a property on ``Session``), so this Just Works
     without any explicit reuse logic.
     """
 
-    def __init__(self, ttl_seconds: int = 3600) -> None:
-        self._sessions: dict[int, Session] = {}
+    def __init__(self, db_path: str | Path, ttl_seconds: int = 3600) -> None:
+        self._db_path = Path(db_path)
         self._ttl = ttl_seconds
+        self._conn: aiosqlite.Connection | None = None
 
-    def create_session(
+    async def connect(self) -> None:
+        """Open the SQLite connection and apply pragmas + schema.
+
+        Safe to call repeatedly; subsequent calls are no-ops once
+        the connection is live.
+        """
+        if self._conn is not None:
+            return
+        # Ensure the parent directory exists. /data is created by the
+        # Dockerfile in production; tests pass a tmp_path that already
+        # exists. Defensive mkdir is cheap and idempotent.
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        conn = await aiosqlite.connect(self._db_path)
+        try:
+            # WAL: concurrent readers, atomic writer, robust to crash.
+            # synchronous=NORMAL: durable enough for session state
+            # (losing the last few writes on a power cut is fine —
+            # we're not a bank). busy_timeout: tolerate momentary
+            # contention on the writer lock without raising.
+            await conn.execute("PRAGMA journal_mode=WAL")
+            await conn.execute("PRAGMA synchronous=NORMAL")
+            await conn.execute("PRAGMA foreign_keys=ON")
+            await conn.execute("PRAGMA busy_timeout=5000")
+            await conn.executescript(_SCHEMA_SQL)
+            # Mark schema version on first connect; INSERT OR IGNORE
+            # so a re-connect on an existing DB doesn't overwrite a
+            # version that may have been bumped by a future migration.
+            await conn.execute(
+                "INSERT OR IGNORE INTO schema_meta (key, value) VALUES (?, ?)",
+                ("schema_version", SCHEMA_VERSION),
+            )
+            await conn.commit()
+        except Exception:
+            await conn.close()
+            raise
+
+        self._conn = conn
+        logger.info("session_manager.connected", db_path=str(self._db_path))
+
+    async def close(self) -> None:
+        """Close the underlying connection. Idempotent."""
+        if self._conn is None:
+            return
+        await self._conn.close()
+        self._conn = None
+
+    def _require_conn(self) -> aiosqlite.Connection:
+        if self._conn is None:
+            raise RuntimeError(
+                "SessionManager.connect() must be awaited before use",
+            )
+        return self._conn
+
+    async def create_session(
         self,
         thread_id: int,
         *,
@@ -87,25 +207,42 @@ class SessionManager:
         ref: str = "HEAD",
         is_private: bool = False,
     ) -> Session:
-        """Create a new session for a thread, optionally bound to a repo.
+        """Create (or replace) the session row for ``thread_id``.
 
         ``repo_url`` and ``ref`` come from the channel's binding (via
         ``RepoConfig``) at thread-creation time — see
-        ``MessageHandler.handle_channel_message``. Stored on the
-        Session so subsequent thread replies inherit the binding
-        without re-querying ``RepoConfig`` and without re-checking
-        the allowlist (bindings are grandfathered).
+        ``MessageHandler.handle_channel_message``. ``is_private`` is
+        sourced from the server's allowlist at the same moment.
+        Caching all three on the row avoids per-reply RepoConfig +
+        allowlist lookups and survives bot restarts.
 
-        ``is_private`` is sourced from the server's allowlist at the
-        same moment — caching it on the Session avoids a per-reply
-        allowlist lookup just to know whether the PAT is required.
-
-        The workspace path is deterministic per thread_id — same
-        directory on the Modal volume across bot restarts and TTL
-        expiries — so Claude Code's ``--continue`` (which keys its
-        history off cwd) finds the prior conversation.
+        ``ON CONFLICT DO UPDATE`` is a deliberate replace — there is
+        only ever one row per thread, and the only legitimate reason
+        to call ``create_session`` on an existing thread is TTL
+        expiry, where ``get_or_create`` has already read the prior
+        row to inherit its bindings before replacing it.
         """
+        conn = self._require_conn()
         session_id = uuid.uuid4().hex[:12]
+        now = time.time()
+        await conn.execute(
+            """
+            INSERT INTO sessions (
+                thread_id, session_id, repo_url, ref, is_private,
+                created_at, last_active_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(thread_id) DO UPDATE SET
+                session_id     = excluded.session_id,
+                repo_url       = excluded.repo_url,
+                ref            = excluded.ref,
+                is_private     = excluded.is_private,
+                created_at     = excluded.created_at,
+                last_active_at = excluded.last_active_at
+            """,
+            (thread_id, session_id, repo_url, ref, int(is_private), now, now),
+        )
+        await conn.commit()
 
         session = Session(
             session_id=session_id,
@@ -113,9 +250,9 @@ class SessionManager:
             repo_url=repo_url,
             ref=ref,
             is_private=is_private,
+            created_at=now,
+            last_active_at=now,
         )
-        self._sessions[thread_id] = session
-
         logger.info(
             "session.created",
             session_id=session_id,
@@ -127,44 +264,58 @@ class SessionManager:
         )
         return session
 
-    def get_session(self, thread_id: int) -> Session | None:
-        """Get session for a thread, or None if not found / expired."""
-        session = self._sessions.get(thread_id)
-        if session is None:
-            return None
+    async def get_session(self, thread_id: int) -> Session | None:
+        """Return the session for ``thread_id`` if present and not expired.
 
+        On hit, bumps ``last_active_at`` to now both in the returned
+        dataclass and in the row, so an actively-used thread doesn't
+        expire mid-conversation.
+        """
+        row = await self._read_row(thread_id)
+        if row is None:
+            return None
+        session = _row_to_session(row)
         if session.is_expired(self._ttl):
             logger.info(
                 "session.expired",
                 session_id=session.session_id,
                 thread_id=thread_id,
             )
-            # Keep workspace, but create fresh session
             return None
 
-        session.touch()
+        # Bump last_active_at — do it in SQL so the persistence
+        # reflects the touch, not just the in-memory copy.
+        conn = self._require_conn()
+        now = time.time()
+        await conn.execute(
+            "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
+            (now, thread_id),
+        )
+        await conn.commit()
+        session.last_active_at = now
         return session
 
-    def get_or_create(self, thread_id: int) -> tuple[Session, bool]:
-        """Get existing session or create new one. Returns (session, is_new).
+    async def get_or_create(self, thread_id: int) -> tuple[Session, bool]:
+        """Return ``(session, is_new)`` — fresh session inherits prior binding.
 
-        On TTL expiry the prior session's ``repo_url`` / ``ref`` are
-        carried over to the fresh session — same Discord thread, same
-        repo binding, fresh Claude Code session. This is what makes
-        a long-running thread keep working after the bot's session
-        TTL fires; the user shouldn't have to re-bind a repo just
-        because their thread went idle for an hour.
+        On TTL expiry the prior row's ``repo_url`` / ``ref`` /
+        ``is_private`` are carried forward to the fresh session.
+        This is what makes a long-running thread keep working after
+        the bot's session TTL fires; the user shouldn't have to
+        re-bind a repo just because their thread went idle for an
+        hour. With persistence, the same inheritance now also
+        survives a bot restart.
         """
-        existing = self.get_session(thread_id)
+        existing = await self.get_session(thread_id)
         if existing is not None:
             return existing, False
 
-        # Check if there was a previous (expired) session and inherit
-        # its repo binding so the fresh session keeps targeting the
-        # same repo.
-        old = self._sessions.get(thread_id)
-        if old is not None:
-            session = self.create_session(
+        # Read the raw row (bypasses TTL gating in get_session) so we
+        # can inherit prior bindings even after expiry.
+        old_row = await self._read_row(thread_id)
+        if old_row is not None:
+            old = _row_to_session(old_row)
+            session = await self.create_session(
                 thread_id,
                 repo_url=old.repo_url,
                 ref=old.ref,
@@ -180,14 +331,51 @@ class SessionManager:
                 is_private=session.is_private,
             )
         else:
-            session = self.create_session(thread_id)
+            session = await self.create_session(thread_id)
 
         return session, True
 
-    def remove(self, thread_id: int) -> None:
-        """Remove a session mapping."""
-        self._sessions.pop(thread_id, None)
+    async def remove(self, thread_id: int) -> None:
+        """Delete a thread's session row. No-op if not present."""
+        conn = self._require_conn()
+        await conn.execute("DELETE FROM sessions WHERE thread_id = ?", (thread_id,))
+        await conn.commit()
 
-    @property
-    def active_count(self) -> int:
-        return sum(1 for s in self._sessions.values() if not s.is_expired(self._ttl))
+    async def active_count(self) -> int:
+        """Count sessions whose last_active_at is within TTL.
+
+        For monitoring/logging only — fine if it's a few ms stale.
+        """
+        conn = self._require_conn()
+        cutoff = time.time() - self._ttl
+        async with conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE last_active_at >= ?",
+            (cutoff,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    async def _read_row(self, thread_id: int) -> tuple | None:
+        conn = self._require_conn()
+        async with conn.execute(
+            """
+            SELECT thread_id, session_id, repo_url, ref, is_private,
+                   created_at, last_active_at
+            FROM sessions WHERE thread_id = ?
+            """,
+            (thread_id,),
+        ) as cursor:
+            return await cursor.fetchone()
+
+
+def _row_to_session(row: tuple) -> Session:
+    """Materialize a Session dataclass from a sessions-table row."""
+    return Session(
+        thread_id=row[0],
+        session_id=row[1],
+        repo_url=row[2],
+        ref=row[3],
+        is_private=bool(row[4]),
+        created_at=row[5],
+        last_active_at=row[6],
+    )

--- a/apps/delulu_discord/src/delulu_discord/settings.py
+++ b/apps/delulu_discord/src/delulu_discord/settings.py
@@ -22,6 +22,13 @@ class Settings(BaseSettings):
     # ── Session behavior ─────────────────────────────────────
     session_ttl_seconds: int = 3600  # 1 hour before session resets
     max_output_length: int = 1900  # Discord limit minus some margin
+    # SQLite file backing SessionManager. Defaults to /data/sessions.db
+    # which is the named-volume mount point set in the Makefile's
+    # `restart` target — the volume survives `docker rm`, so per-thread
+    # sessions persist across deploys (the bug fixed by this layer).
+    # Override to a tmp path in tests; override to anywhere else for
+    # local-dev runs that don't have the /data mount.
+    session_db_path: str = "/data/sessions.db"
 
     # ── Repo provisioning ────────────────────────────────────
     # The bare-cache root on the Modal Volume. Mirrors the constant

--- a/apps/delulu_discord/tests/test_session_manager.py
+++ b/apps/delulu_discord/tests/test_session_manager.py
@@ -1,0 +1,395 @@
+"""Tests for the SQLite-backed SessionManager.
+
+The whole point of moving SessionManager off an in-memory dict was
+to survive bot restarts. The two load-bearing tests here are:
+
+- ``test_persists_across_restart`` — write with one ``SessionManager``
+  instance, read with a fresh one against the same DB file. This is
+  the regression for the ``setrepo-persistence-bug`` symptom; if it
+  ever fails, /setrepo bindings will silently vanish across deploys
+  again.
+- ``test_get_or_create_inherits_after_expiry`` — confirms the
+  grandfathering semantic survives across both TTL expiry and
+  restart, since both paths hit the same row-inheritance code.
+
+Other tests cover field round-trips, TTL gating, concurrent writes,
+and the connect/close lifecycle. Tests use ``tmp_path`` for isolation
+and rely on ``asyncio_mode = "auto"`` from ``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+from delulu_discord.session_manager import (
+    SCHEMA_VERSION,
+    Session,
+    SessionManager,
+    _row_to_session,
+)
+
+
+@pytest.fixture
+async def sm(tmp_path: Path):
+    """Yield a connected SessionManager pointed at a per-test SQLite file."""
+    manager = SessionManager(db_path=tmp_path / "sessions.db", ttl_seconds=3600)
+    await manager.connect()
+    try:
+        yield manager
+    finally:
+        await manager.close()
+
+
+class TestLifecycle:
+    async def test_use_before_connect_raises(self, tmp_path: Path):
+        # Forgetting ``await connect()`` is a programming error, not
+        # a recoverable runtime condition. RuntimeError surfaces it
+        # at the first call instead of letting a None propagate.
+        manager = SessionManager(db_path=tmp_path / "sessions.db")
+        with pytest.raises(RuntimeError, match="connect"):
+            await manager.create_session(thread_id=1)
+
+    async def test_connect_is_idempotent(self, tmp_path: Path):
+        manager = SessionManager(db_path=tmp_path / "sessions.db")
+        await manager.connect()
+        await manager.connect()  # second call must be a no-op, not raise
+        try:
+            await manager.create_session(thread_id=1)
+        finally:
+            await manager.close()
+
+    async def test_close_is_idempotent(self, tmp_path: Path):
+        manager = SessionManager(db_path=tmp_path / "sessions.db")
+        await manager.connect()
+        await manager.close()
+        await manager.close()  # second close is a no-op
+
+    async def test_creates_parent_directory(self, tmp_path: Path):
+        # /data won't exist on a fresh dev box; connect() must mkdir
+        # the parent rather than blowing up.
+        nested = tmp_path / "a" / "b" / "c" / "sessions.db"
+        manager = SessionManager(db_path=nested)
+        await manager.connect()
+        try:
+            assert nested.parent.is_dir()
+        finally:
+            await manager.close()
+
+    async def test_records_schema_version(self, tmp_path: Path):
+        manager = SessionManager(db_path=tmp_path / "sessions.db")
+        await manager.connect()
+        try:
+            conn = manager._conn
+            assert conn is not None
+            async with conn.execute(
+                "SELECT value FROM schema_meta WHERE key = ?",
+                ("schema_version",),
+            ) as cursor:
+                row = await cursor.fetchone()
+            assert row is not None
+            assert row[0] == SCHEMA_VERSION
+        finally:
+            await manager.close()
+
+
+class TestCreateGetRoundtrip:
+    async def test_full_field_roundtrip(self, sm: SessionManager):
+        # All fields the dataclass cares about — repo_url, ref,
+        # is_private — must round-trip through SQLite without drift.
+        # is_private is the trickiest (stored as INTEGER 0/1, cast
+        # back to bool on read) so the assertion explicitly checks
+        # the type, not just truthiness.
+        before = time.time()
+        created = await sm.create_session(
+            thread_id=42,
+            repo_url="https://github.com/alice/api-service",
+            ref="main",
+            is_private=True,
+        )
+        after = time.time()
+
+        assert created.thread_id == 42
+        assert created.repo_url == "https://github.com/alice/api-service"
+        assert created.ref == "main"
+        assert created.is_private is True
+        assert before <= created.created_at <= after
+        assert created.session_id  # non-empty
+
+        got = await sm.get_session(42)
+        assert got is not None
+        assert got.session_id == created.session_id
+        assert got.repo_url == created.repo_url
+        assert got.ref == created.ref
+        assert got.is_private is True
+        assert isinstance(got.is_private, bool)
+
+    async def test_unbound_repo_url_is_none(self, sm: SessionManager):
+        # repo_url=None is the general-Q&A path. SQLite stores it as
+        # NULL; the read must come back as Python None, not "" or
+        # the string "None".
+        await sm.create_session(thread_id=1)
+        got = await sm.get_session(1)
+        assert got is not None
+        assert got.repo_url is None
+        assert got.is_private is False
+        assert got.ref == "HEAD"
+
+    async def test_get_missing_returns_none(self, sm: SessionManager):
+        assert await sm.get_session(999) is None
+
+
+class TestPersistence:
+    async def test_persists_across_restart(self, tmp_path: Path):
+        """Regression test for setrepo-persistence-bug.md.
+
+        Writing with one SessionManager and reading with a fresh
+        instance against the same DB file MUST return the same data
+        — that is the entire point of moving off the in-memory dict.
+        If this test ever flips, /setrepo bindings will silently
+        vanish on every deploy again.
+        """
+        db = tmp_path / "sessions.db"
+        first = SessionManager(db_path=db, ttl_seconds=3600)
+        await first.connect()
+        try:
+            created = await first.create_session(
+                thread_id=12345,
+                repo_url="https://github.com/alice/private-svc",
+                ref="main",
+                is_private=True,
+            )
+            written_session_id = created.session_id
+        finally:
+            await first.close()
+
+        # Fresh process / fresh manager. The DB file is the only
+        # state carried over — same as a Docker `restart` cycle on
+        # the VPS, where the named volume holds /data/sessions.db.
+        second = SessionManager(db_path=db, ttl_seconds=3600)
+        await second.connect()
+        try:
+            got = await second.get_session(12345)
+            assert got is not None
+            assert got.session_id == written_session_id
+            assert got.repo_url == "https://github.com/alice/private-svc"
+            assert got.ref == "main"
+            assert got.is_private is True
+        finally:
+            await second.close()
+
+
+class TestTTLExpiry:
+    async def test_expired_session_returns_none(self, tmp_path: Path):
+        # TTL is checked in Python (last_active_at vs time.time()),
+        # not in SQL — so the row stays in the table for
+        # get_or_create's grandfathering logic to read.
+        manager = SessionManager(db_path=tmp_path / "s.db", ttl_seconds=1)
+        await manager.connect()
+        try:
+            await manager.create_session(thread_id=1, repo_url="x")
+            # Backdate last_active_at so it's outside the 1s TTL.
+            conn = manager._conn
+            assert conn is not None
+            await conn.execute(
+                "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
+                (time.time() - 10, 1),
+            )
+            await conn.commit()
+
+            assert await manager.get_session(1) is None
+        finally:
+            await manager.close()
+
+    async def test_get_session_bumps_last_active(self, sm: SessionManager):
+        # Hot-thread protection: any reply in a thread should reset
+        # the TTL clock so a long conversation doesn't get cut off
+        # mid-flight.
+        await sm.create_session(thread_id=1, repo_url="x")
+        # Backdate enough to register but stay within TTL (3600s).
+        conn = sm._conn
+        assert conn is not None
+        backdated = time.time() - 100
+        await conn.execute(
+            "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
+            (backdated, 1),
+        )
+        await conn.commit()
+
+        got = await sm.get_session(1)
+        assert got is not None
+        assert got.last_active_at > backdated
+
+
+class TestGetOrCreate:
+    async def test_returns_existing(self, sm: SessionManager):
+        first = await sm.create_session(thread_id=1, repo_url="r")
+        got, is_new = await sm.get_or_create(1)
+        assert is_new is False
+        assert got.session_id == first.session_id
+
+    async def test_creates_when_missing(self, sm: SessionManager):
+        got, is_new = await sm.get_or_create(1)
+        assert is_new is True
+        assert got.thread_id == 1
+        assert got.repo_url is None
+
+    async def test_inherits_after_expiry(self, tmp_path: Path):
+        # After TTL expiry the prior row's repo_url / ref /
+        # is_private are carried into the fresh session. Without
+        # this the user would have to re-/setrepo every hour.
+        manager = SessionManager(db_path=tmp_path / "s.db", ttl_seconds=1)
+        await manager.connect()
+        try:
+            original = await manager.create_session(
+                thread_id=1,
+                repo_url="https://github.com/alice/api",
+                ref="release-1.4",
+                is_private=True,
+            )
+            # Backdate to force expiry.
+            conn = manager._conn
+            assert conn is not None
+            await conn.execute(
+                "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
+                (time.time() - 10, 1),
+            )
+            await conn.commit()
+
+            new_session, is_new = await manager.get_or_create(1)
+            assert is_new is True
+            assert new_session.session_id != original.session_id
+            assert new_session.repo_url == "https://github.com/alice/api"
+            assert new_session.ref == "release-1.4"
+            assert new_session.is_private is True
+        finally:
+            await manager.close()
+
+    async def test_inherits_across_restart(self, tmp_path: Path):
+        # Combines the previous two regressions: a session expired
+        # before the bot was restarted should still inherit on the
+        # first get_or_create after the restart.
+        db = tmp_path / "s.db"
+
+        first = SessionManager(db_path=db, ttl_seconds=1)
+        await first.connect()
+        try:
+            await first.create_session(
+                thread_id=7,
+                repo_url="https://github.com/alice/foo",
+                ref="dev",
+                is_private=False,
+            )
+            conn = first._conn
+            assert conn is not None
+            await conn.execute(
+                "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
+                (time.time() - 10, 7),
+            )
+            await conn.commit()
+        finally:
+            await first.close()
+
+        second = SessionManager(db_path=db, ttl_seconds=1)
+        await second.connect()
+        try:
+            new_session, is_new = await second.get_or_create(7)
+            assert is_new is True
+            assert new_session.repo_url == "https://github.com/alice/foo"
+            assert new_session.ref == "dev"
+            assert new_session.is_private is False
+        finally:
+            await second.close()
+
+
+class TestRemove:
+    async def test_remove_existing(self, sm: SessionManager):
+        await sm.create_session(thread_id=1)
+        await sm.remove(1)
+        assert await sm.get_session(1) is None
+
+    async def test_remove_missing_is_noop(self, sm: SessionManager):
+        # Sometimes the bot races a session cleanup against a
+        # /setrepo unbind; both shouldn't error.
+        await sm.remove(999)
+
+
+class TestActiveCount:
+    async def test_counts_only_active(self, tmp_path: Path):
+        manager = SessionManager(db_path=tmp_path / "s.db", ttl_seconds=10)
+        await manager.connect()
+        try:
+            await manager.create_session(thread_id=1)
+            await manager.create_session(thread_id=2)
+            await manager.create_session(thread_id=3)
+            # Backdate one outside the TTL window.
+            conn = manager._conn
+            assert conn is not None
+            await conn.execute(
+                "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
+                (time.time() - 1000, 2),
+            )
+            await conn.commit()
+
+            assert await manager.active_count() == 2
+        finally:
+            await manager.close()
+
+
+class TestConcurrency:
+    async def test_concurrent_get_or_create_yields_one_row(self, sm: SessionManager):
+        # Two coroutines racing on the same thread_id must not produce
+        # two distinct session IDs in the table. SQLite's PK
+        # constraint + ON CONFLICT handles this; aiosqlite serializes
+        # both writes through one background thread, so the second
+        # call effectively sees the first call's row.
+        results = await asyncio.gather(
+            sm.get_or_create(42),
+            sm.get_or_create(42),
+        )
+        sessions = [r[0] for r in results]
+
+        # Whatever happens at the create layer, the persisted row
+        # must be a single session by the end. Read-back is the
+        # source of truth.
+        got = await sm.get_session(42)
+        assert got is not None
+        # Both callers should hold a Session referring to the same
+        # thread; at least one of them should match the persisted
+        # session_id.
+        assert any(s.session_id == got.session_id for s in sessions)
+
+
+class TestRowToSession:
+    def test_handles_int_is_private_zero(self):
+        row = (1, "abc", "url", "main", 0, 1.0, 2.0)
+        s = _row_to_session(row)
+        assert s.is_private is False
+        assert isinstance(s.is_private, bool)
+
+    def test_handles_int_is_private_one(self):
+        row = (1, "abc", "url", "main", 1, 1.0, 2.0)
+        s = _row_to_session(row)
+        assert s.is_private is True
+
+    def test_handles_null_repo_url(self):
+        row = (1, "abc", None, "HEAD", 0, 1.0, 2.0)
+        s = _row_to_session(row)
+        assert s.repo_url is None
+
+
+class TestSessionDataclass:
+    def test_workspace_path_property(self):
+        s = Session(session_id="x", thread_id=12345)
+        assert s.workspace_path == "/vol/workspaces/12345"
+
+    def test_is_expired_true_past_ttl(self):
+        s = Session(session_id="x", thread_id=1, last_active_at=time.time() - 100)
+        assert s.is_expired(ttl_seconds=10)
+
+    def test_is_expired_false_within_ttl(self):
+        s = Session(session_id="x", thread_id=1, last_active_at=time.time())
+        assert not s.is_expired(ttl_seconds=10)

--- a/apps/delulu_discord/uv.lock
+++ b/apps/delulu_discord/uv.lock
@@ -75,6 +75,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -204,6 +213,7 @@ name = "delulu-discord"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "discord-py" },
     { name = "modal" },
     { name = "pydantic" },
@@ -220,6 +230,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.20" },
     { name = "discord-py", specifier = ">=2.4,<3" },
     { name = "modal", specifier = ">=1.0" },
     { name = "pydantic", specifier = ">=2.0,<3" },


### PR DESCRIPTION
## Summary

Closes the \"every deploy loses /setrepo bindings\" symptom. The bindings themselves were already durable (`modal.Dict`); what wasn't surviving deploys was the **in-memory `SessionManager._sessions` dict** — a per-thread cache that `handle_channel_message` writes the repo binding into, and that `handle_thread_reply` reads from **without ever re-consulting `RepoConfig`**. Every \`docker rm\` (Makefile's `restart` target) wiped that cache, and the next reply in any open thread fell through to the empty-workspace path.

Diagnostic was confirmed by dumping the Modal dicts (`modal dict items discord-orchestrator-repo-config`) — both repo-config and allowlist had data after a deploy. Writes were never the problem.

## Fix shape

- `SessionManager` rewritten on `aiosqlite` + a single long-lived connection (WAL mode, `busy_timeout=5000`).
- One row per `thread_id` (PK). `schema_meta` table reserves a `schema_version` for future migrations.
- API stays semantically identical (TTL gating, `last_active_at` touch, grandfathering on `get_or_create` after expiry) but methods become `async`.
- `/data/sessions.db` lives on a **named Docker volume `disco-data`** mounted in the Makefile's `restart` target — that's what survives `docker rm`. Volume is created automatically on first `docker run -v` (no manual setup).
- Dockerfile gets a `mkdir -p /data` so the first deploy starts cleanly before the volume has contents.

## Files

- `session_manager.py` — full rewrite (~300 lines).
- `main.py` — wraps `client.start` in an async `_run()` that does `connect()` ... `try`/`finally` `close()`. `on_message` thread-reply check awaits `get_session`.
- `handlers.py`, `commands.py` — `await` propagated to every call site.
- `Dockerfile`, `Makefile` — `/data` dir + `disco-data` volume.
- `pyproject.toml` — `aiosqlite>=0.20`.
- `settings.py` — `session_db_path: str = \"/data/sessions.db\"`.
- `tests/test_session_manager.py` (new, 25 tests).

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pytest` — 77 passed (25 new in `test_session_manager.py`)

Two regression tests carry the load:
- `test_persists_across_restart` — write with one `SessionManager`, read with a fresh instance against the same DB file. If this ever flips, /setrepo bindings vanish on every deploy again.
- `test_inherits_across_restart` — TTL expiry's grandfathering of `repo_url`/`ref`/`is_private` survives a \"restart\".

Plus full-field round-trip (incl. `is_private` 0/1 → bool cast and `repo_url=None`), TTL gating, `last_active_at` touch, `get_or_create` paths, concurrent `get_or_create` doesn't double-insert, lifecycle (use-before-connect raises, idempotent connect/close, parent-dir mkdir, schema_meta version).

- [ ] Deploy. After the deploy that lands this, verify `/setrepo` bindings persist by:
  1. \`/setrepo\` in a channel.
  2. \`@delulu\` mention there → confirm the repo subtitle shows.
  3. SSH into the droplet, \`make -C apps/delulu_discord restart\`.
  4. Reply in the same thread → confirm the binding is still there (subtitle still shows).

## Deployment notes

- One-time loss: existing in-memory sessions go away on the deploy that lands this — which is what was happening on every deploy anyway. Future deploys preserve them.
- Single-replica only. WAL handles concurrent processes on the same host file, but two droplets writing to the same volume would corrupt the DB. Documented in the `SessionManager` docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)