### PR TITLE
refactor(delulu): SessionManager hot-path + janitor cleanups

### DIFF
--- a/apps/delulu_discord/src/delulu_discord/main.py
+++ b/apps/delulu_discord/src/delulu_discord/main.py
@@ -27,8 +27,13 @@ def _strip_mention(content: str, bot_id: int) -> str:
     return re.sub(rf"<@!?{bot_id}>", "", content).strip()
 
 
-def create_bot(settings: Settings) -> discord.Client:
-    """Create and configure the Discord client."""
+def create_bot(settings: Settings) -> tuple[discord.Client, SessionManager]:
+    """Create and configure the Discord client.
+
+    Returns ``(client, session_manager)`` so the caller can drive
+    the SessionManager's ``connect()`` / ``close()`` lifecycle in
+    the same event loop as ``client.start``.
+    """
     intents = discord.Intents.default()
     intents.message_content = True
     intents.guilds = True
@@ -41,9 +46,6 @@ def create_bot(settings: Settings) -> discord.Client:
     tree = app_commands.CommandTree(client)
 
     # ── Wire up components ───────────────────────────────────
-    # Persistent SQLite-backed session store. Caller (``main()``)
-    # awaits ``session_manager.connect()`` before ``client.start``
-    # so the schema is in place by the time the first message lands.
     session_manager = SessionManager(
         db_path=settings.session_db_path,
         ttl_seconds=settings.session_ttl_seconds,
@@ -71,12 +73,6 @@ def create_bot(settings: Settings) -> discord.Client:
         session_manager=session_manager,
         dispatcher=dispatcher,
     )
-
-    # Stash on the client so ``main()._run`` can reach it for
-    # ``connect()`` / ``close()`` without changing this function's
-    # return signature. discord.Client doesn't reserve underscore
-    # attributes, so this is safe.
-    client._session_manager = session_manager  # type: ignore[attr-defined]
 
     # ── Event handlers ───────────────────────────────────────
     @client.event
@@ -138,24 +134,17 @@ def create_bot(settings: Settings) -> discord.Client:
                 return
             await handler.handle_channel_message(message, prompt)
 
-    return client
+    return client, session_manager
 
 
 async def _run(settings: Settings) -> None:
     """Bring up SessionManager, start the Discord client, tear down cleanly.
 
-    Split out so ``client.start(...)`` runs in the same event loop as
-    ``await session_manager.connect()`` and ``await
-    session_manager.close()``. The ``finally`` runs on KeyboardInterrupt
-    and on Discord-side exceptions alike, so the SQLite WAL gets
-    checkpointed and the connection released even on hard restarts.
+    The ``finally`` runs on KeyboardInterrupt and on Discord-side
+    exceptions alike, so the SQLite WAL gets checkpointed and the
+    connection released even on hard restarts.
     """
-    client = create_bot(settings)
-    # ``client._session_manager`` is set by ``create_bot`` for the
-    # lifecycle hooks here; pulling it back out keeps the wiring in
-    # one place. Plain attribute access on discord.Client is fine —
-    # the library doesn't reserve underscore-prefixed names.
-    session_manager: SessionManager = client._session_manager  # type: ignore[attr-defined]
+    client, session_manager = create_bot(settings)
     await session_manager.connect()
     try:
         await client.start(settings.discord_bot_token)

--- a/apps/delulu_discord/src/delulu_discord/session_manager.py
+++ b/apps/delulu_discord/src/delulu_discord/session_manager.py
@@ -48,6 +48,22 @@ logger = structlog.get_logger()
 # Bumped when the schema changes in a way that requires a migration.
 # Read on connect from ``schema_meta``; new columns can branch on it.
 SCHEMA_VERSION = "1"
+SCHEMA_VERSION_KEY = "schema_version"
+
+# How recent ``last_active_at`` must be before ``get_session`` skips
+# its persistence-side touch. The bot is on a single replica with an
+# hour-long TTL, so a few seconds of drift on the persisted clock is
+# invisible across restarts; meanwhile the in-memory ``Session`` is
+# still updated, so TTL gating in this process stays exact. Trading
+# this for an UPDATE+commit on every Discord message in an active
+# thread is the load-bearing perf win in this module.
+TOUCH_DEBOUNCE_SECONDS = 60
+
+# Rows whose ``last_active_at`` is older than this on connect get
+# swept by the startup janitor. The TTL window is an hour; anything
+# 30 days idle is dead. Sweeping at connect (not on a timer) keeps
+# the lifecycle predictable without a background task.
+JANITOR_MAX_AGE_DAYS = 30
 
 # Idempotent schema. ``CREATE TABLE IF NOT EXISTS`` makes connect()
 # safe to call against a fresh DB or an existing one. Index on
@@ -148,42 +164,53 @@ class SessionManager:
     async def connect(self) -> None:
         """Open the SQLite connection and apply pragmas + schema.
 
-        Safe to call repeatedly; subsequent calls are no-ops once
-        the connection is live.
+        Idempotent. Sweeps rows older than ``JANITOR_MAX_AGE_DAYS``
+        before serving any request, so the table size stays bounded
+        without a background task.
         """
         if self._conn is not None:
             return
-        # Ensure the parent directory exists. /data is created by the
-        # Dockerfile in production; tests pass a tmp_path that already
-        # exists. Defensive mkdir is cheap and idempotent.
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
 
         conn = await aiosqlite.connect(self._db_path)
         try:
             # WAL: concurrent readers, atomic writer, robust to crash.
             # synchronous=NORMAL: durable enough for session state
-            # (losing the last few writes on a power cut is fine —
-            # we're not a bank). busy_timeout: tolerate momentary
-            # contention on the writer lock without raising.
-            await conn.execute("PRAGMA journal_mode=WAL")
-            await conn.execute("PRAGMA synchronous=NORMAL")
-            await conn.execute("PRAGMA foreign_keys=ON")
-            await conn.execute("PRAGMA busy_timeout=5000")
-            await conn.executescript(_SCHEMA_SQL)
-            # Mark schema version on first connect; INSERT OR IGNORE
-            # so a re-connect on an existing DB doesn't overwrite a
-            # version that may have been bumped by a future migration.
+            # (losing the last few writes on a power cut is fine).
+            # busy_timeout: tolerate momentary writer-lock contention.
+            await conn.executescript(
+                "PRAGMA journal_mode=WAL;"
+                "PRAGMA synchronous=NORMAL;"
+                "PRAGMA foreign_keys=ON;"
+                "PRAGMA busy_timeout=5000;" + _SCHEMA_SQL
+            )
+            # INSERT OR IGNORE so a reconnect on an existing DB
+            # doesn't clobber a version a future migration bumped.
             await conn.execute(
                 "INSERT OR IGNORE INTO schema_meta (key, value) VALUES (?, ?)",
-                ("schema_version", SCHEMA_VERSION),
+                (SCHEMA_VERSION_KEY, SCHEMA_VERSION),
             )
             await conn.commit()
+            self._conn = conn
+            await self._run_janitor()
         except Exception:
+            self._conn = None
             await conn.close()
             raise
 
-        self._conn = conn
         logger.info("session_manager.connected", db_path=str(self._db_path))
+
+    async def _run_janitor(self) -> None:
+        conn = self._require_conn()
+        cutoff = time.time() - JANITOR_MAX_AGE_DAYS * 86400
+        async with conn.execute(
+            "DELETE FROM sessions WHERE last_active_at < ?",
+            (cutoff,),
+        ) as cursor:
+            deleted = cursor.rowcount
+        await conn.commit()
+        if deleted:
+            logger.info("session_manager.janitor_swept", deleted=deleted)
 
     async def close(self) -> None:
         """Close the underlying connection. Idempotent."""
@@ -267,9 +294,12 @@ class SessionManager:
     async def get_session(self, thread_id: int) -> Session | None:
         """Return the session for ``thread_id`` if present and not expired.
 
-        On hit, bumps ``last_active_at`` to now both in the returned
-        dataclass and in the row, so an actively-used thread doesn't
-        expire mid-conversation.
+        On hit, bumps ``last_active_at`` to now — but only persists
+        the bump when the row hasn't been touched within
+        ``TOUCH_DEBOUNCE_SECONDS``. The in-memory copy is always
+        updated so TTL gating stays exact within a process; the DB
+        write is what we're throttling, since this is on the
+        every-message hot path.
         """
         row = await self._read_row(thread_id)
         if row is None:
@@ -283,15 +313,14 @@ class SessionManager:
             )
             return None
 
-        # Bump last_active_at — do it in SQL so the persistence
-        # reflects the touch, not just the in-memory copy.
-        conn = self._require_conn()
         now = time.time()
-        await conn.execute(
-            "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
-            (now, thread_id),
-        )
-        await conn.commit()
+        if now - session.last_active_at >= TOUCH_DEBOUNCE_SECONDS:
+            conn = self._require_conn()
+            await conn.execute(
+                "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
+                (now, thread_id),
+            )
+            await conn.commit()
         session.last_active_at = now
         return session
 

--- a/apps/delulu_discord/tests/test_session_manager.py
+++ b/apps/delulu_discord/tests/test_session_manager.py
@@ -26,7 +26,10 @@ from pathlib import Path
 import pytest
 
 from delulu_discord.session_manager import (
+    JANITOR_MAX_AGE_DAYS,
     SCHEMA_VERSION,
+    SCHEMA_VERSION_KEY,
+    TOUCH_DEBOUNCE_SECONDS,
     Session,
     SessionManager,
     _row_to_session,
@@ -42,6 +45,25 @@ async def sm(tmp_path: Path):
         yield manager
     finally:
         await manager.close()
+
+
+async def _backdate(manager: SessionManager, thread_id: int, seconds_ago: float) -> float:
+    """Push ``last_active_at`` for ``thread_id`` ``seconds_ago`` into the past.
+
+    Returns the new ``last_active_at`` so callers can assert exact
+    bumps. Reaches into ``manager._conn`` rather than going through
+    a public method because there's no public way to backdate, and
+    a real test against the time clock would be flaky.
+    """
+    conn = manager._conn
+    assert conn is not None
+    backdated = time.time() - seconds_ago
+    await conn.execute(
+        "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
+        (backdated, thread_id),
+    )
+    await conn.commit()
+    return backdated
 
 
 class TestLifecycle:
@@ -87,7 +109,7 @@ class TestLifecycle:
             assert conn is not None
             async with conn.execute(
                 "SELECT value FROM schema_meta WHERE key = ?",
-                ("schema_version",),
+                (SCHEMA_VERSION_KEY,),
             ) as cursor:
                 row = await cursor.fetchone()
             assert row is not None
@@ -191,37 +213,50 @@ class TestTTLExpiry:
         await manager.connect()
         try:
             await manager.create_session(thread_id=1, repo_url="x")
-            # Backdate last_active_at so it's outside the 1s TTL.
-            conn = manager._conn
-            assert conn is not None
-            await conn.execute(
-                "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
-                (time.time() - 10, 1),
-            )
-            await conn.commit()
-
+            await _backdate(manager, 1, seconds_ago=10)
             assert await manager.get_session(1) is None
         finally:
             await manager.close()
 
     async def test_get_session_bumps_last_active(self, sm: SessionManager):
-        # Hot-thread protection: any reply in a thread should reset
-        # the TTL clock so a long conversation doesn't get cut off
-        # mid-flight.
+        # Hot-thread protection: a reply in a thread that's been
+        # idle longer than TOUCH_DEBOUNCE_SECONDS resets the TTL
+        # clock so a long conversation doesn't get cut off
+        # mid-flight. Backdate well past the debounce window so the
+        # bump-path runs (the recently-touched path is exercised by
+        # test_get_session_skips_bump_within_debounce below).
         await sm.create_session(thread_id=1, repo_url="x")
-        # Backdate enough to register but stay within TTL (3600s).
-        conn = sm._conn
-        assert conn is not None
-        backdated = time.time() - 100
-        await conn.execute(
-            "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
-            (backdated, 1),
-        )
-        await conn.commit()
+        backdated = await _backdate(sm, 1, seconds_ago=TOUCH_DEBOUNCE_SECONDS + 5)
 
         got = await sm.get_session(1)
         assert got is not None
         assert got.last_active_at > backdated
+
+    async def test_get_session_skips_bump_within_debounce(self, sm: SessionManager):
+        # Within the debounce window, get_session must NOT issue an
+        # UPDATE. This is the load-bearing perf win: the bot's hot
+        # path (every Discord message) does a SELECT only — no
+        # writer lock, no commit, no fsync.
+        await sm.create_session(thread_id=1, repo_url="x")
+        # Half-way into the debounce window: still "recent."
+        backdated = await _backdate(sm, 1, seconds_ago=TOUCH_DEBOUNCE_SECONDS / 2)
+
+        await sm.get_session(1)
+
+        # Re-read the persisted row directly; it must still hold the
+        # backdated value (no UPDATE issued). In-memory copies on
+        # the returned dataclass are allowed to bump — the test
+        # above covers that — what we're asserting here is that the
+        # *DB* didn't get touched.
+        conn = sm._conn
+        assert conn is not None
+        async with conn.execute(
+            "SELECT last_active_at FROM sessions WHERE thread_id = ?",
+            (1,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        assert row[0] == pytest.approx(backdated, abs=1e-3)
 
 
 class TestGetOrCreate:
@@ -250,14 +285,7 @@ class TestGetOrCreate:
                 ref="release-1.4",
                 is_private=True,
             )
-            # Backdate to force expiry.
-            conn = manager._conn
-            assert conn is not None
-            await conn.execute(
-                "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
-                (time.time() - 10, 1),
-            )
-            await conn.commit()
+            await _backdate(manager, 1, seconds_ago=10)
 
             new_session, is_new = await manager.get_or_create(1)
             assert is_new is True
@@ -283,13 +311,7 @@ class TestGetOrCreate:
                 ref="dev",
                 is_private=False,
             )
-            conn = first._conn
-            assert conn is not None
-            await conn.execute(
-                "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
-                (time.time() - 10, 7),
-            )
-            await conn.commit()
+            await _backdate(first, 7, seconds_ago=10)
         finally:
             await first.close()
 
@@ -325,18 +347,72 @@ class TestActiveCount:
             await manager.create_session(thread_id=1)
             await manager.create_session(thread_id=2)
             await manager.create_session(thread_id=3)
-            # Backdate one outside the TTL window.
-            conn = manager._conn
-            assert conn is not None
-            await conn.execute(
-                "UPDATE sessions SET last_active_at = ? WHERE thread_id = ?",
-                (time.time() - 1000, 2),
-            )
-            await conn.commit()
+            await _backdate(manager, 2, seconds_ago=1000)
 
             assert await manager.active_count() == 2
         finally:
             await manager.close()
+
+
+class TestJanitor:
+    """Startup janitor sweeps rows older than ``JANITOR_MAX_AGE_DAYS``.
+
+    Without this, the table would grow unboundedly with every
+    Discord thread the bot has ever served. Sweeping at connect()
+    keeps the lifecycle predictable (no background task) and bounds
+    the table to roughly the last 30 days of active threads.
+    """
+
+    async def test_sweeps_rows_older_than_max_age(self, tmp_path: Path):
+        db = tmp_path / "s.db"
+
+        # First connect: seed two rows, one well past JANITOR_MAX_AGE_DAYS
+        # and one fresh. Reset both backdates *after* create_session so
+        # they survive the seed-time touch.
+        first = SessionManager(db_path=db, ttl_seconds=3600)
+        await first.connect()
+        try:
+            await first.create_session(thread_id=100, repo_url="stale")
+            await first.create_session(thread_id=200, repo_url="fresh")
+            await _backdate(
+                first,
+                100,
+                seconds_ago=(JANITOR_MAX_AGE_DAYS + 1) * 86400,
+            )
+        finally:
+            await first.close()
+
+        # Second connect runs the janitor on the seeded DB. The stale
+        # row must be gone; the fresh row must be untouched.
+        second = SessionManager(db_path=db, ttl_seconds=3600)
+        await second.connect()
+        try:
+            assert await second.get_session(100) is None
+            fresh = await second.get_session(200)
+            assert fresh is not None
+            assert fresh.repo_url == "fresh"
+        finally:
+            await second.close()
+
+    async def test_no_sweep_keeps_recent_rows(self, tmp_path: Path):
+        # Sanity check: a connect that finds nothing to sweep must
+        # not delete anything (and must not crash).
+        db = tmp_path / "s.db"
+        first = SessionManager(db_path=db)
+        await first.connect()
+        try:
+            await first.create_session(thread_id=1, repo_url="recent")
+        finally:
+            await first.close()
+
+        second = SessionManager(db_path=db)
+        await second.connect()
+        try:
+            got = await second.get_session(1)
+            assert got is not None
+            assert got.repo_url == "recent"
+        finally:
+            await second.close()
 
 
 class TestConcurrency:


### PR DESCRIPTION
## Summary

Follow-up to #74. After the merge, an after-the-fact \`/simplify\` review (three parallel agents — reuse, quality, efficiency) flagged one load-bearing perf issue and a few cleanups.

## What's in here

**Hot-path (the load-bearer):** every Discord message in an active thread was doing SELECT + UPDATE + commit on the sessions table — every read was acquiring the writer lock and fsyncing the WAL. Now \`get_session\` only persists the \`last_active_at\` bump if the row hasn't been touched within \`TOUCH_DEBOUNCE_SECONDS\` (60s). The in-memory dataclass is still bumped every hit (so TTL gating stays exact within the process); we're just throttling the DB write.

**Janitor:** \`connect()\` sweeps rows older than \`JANITOR_MAX_AGE_DAYS\` (30) before serving any request. Bounds the table without a background task. Anything 30 days idle is dead — the TTL window is an hour.

**Cleanup of #74's \`client._session_manager\` attr stash:** \`create_bot\` now returns \`(client, session_manager)\` instead of stashing on a private attribute. Two apologetic block comments deleted.

**Misc:** four PRAGMA round-trips in \`connect()\` collapsed into one \`executescript\` (startup-only micro-opt). \`SCHEMA_VERSION_KEY\` module constant. Test helper \`_backdate(manager, thread_id, seconds_ago)\` replaces five inline UPDATE blocks across four test classes.

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pytest\` — 80 passed (3 new):
  - \`test_get_session_skips_bump_within_debounce\` — asserts the persisted row is NOT touched on a recent read.
  - \`test_sweeps_rows_older_than_max_age\` — seeds a row backdated past the cutoff with one manager, verifies the next \`connect()\` sweeps it.
  - \`test_no_sweep_keeps_recent_rows\` — sanity: the no-op janitor case must not crash or delete anything.

## Notes

The debounce skip is observable across restarts (a recently-touched session might persist a slightly older \`last_active_at\` than the in-process clock thinks). At one-hour TTL with 60s debounce, this never matters for TTL gating. Documented in the \`TOUCH_DEBOUNCE_SECONDS\` constant docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)