### PR TITLE
chore(delulu): switch bot container to journald log driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,10 @@ without pushing a commit:
    - `pr-title-lint` only runs on `pull_request` events, so on a
      manual dispatch it's skipped
 3. On the droplet, `docker ps` should show the `disco` container running,
-   and `docker logs disco` should show a clean startup.
+   and `journalctl CONTAINER_NAME=disco --since "5 minutes ago"` (or
+   `make -C apps/delulu_discord logs`) should show a clean startup.
+   The bot uses the journald log driver so logs survive container
+   rebuilds — `docker logs disco` still works for the current run.
 
 Each job's logs are viewable independently in the Actions UI — no need
 to SSH in to debug unless the failure is in the droplet-side step.

--- a/apps/delulu_discord/Makefile
+++ b/apps/delulu_discord/Makefile
@@ -51,9 +51,19 @@ image:
 restart:
 	-docker stop $(BOT_NAME)
 	-docker rm $(BOT_NAME)
+	# --log-driver=journald: ship container stdout/stderr to systemd-journald
+	# instead of Docker's default json-file driver. The default writes to a
+	# per-container file under /var/lib/docker/containers/<id>/ that is
+	# deleted with `docker rm` — every `make deploy` would wipe history,
+	# making post-mortems on cancellations or crashes impossible across a
+	# rebuild. journald survives container removal, restarts, and host
+	# reboots (assuming /var/log/journal/ exists; create it with
+	# `sudo mkdir -p /var/log/journal && sudo systemctl restart systemd-journald`
+	# if it doesn't).
 	docker run -d \
 	  --name $(BOT_NAME) \
 	  --restart=unless-stopped \
+	  --log-driver=journald \
 	  --env-file $(ENV_FILE) \
 	  -v $(MODAL_TOML):/root/.modal.toml:ro \
 	  -v $(DATA_VOLUME):/data \
@@ -61,8 +71,12 @@ restart:
 
 deploy: image restart
 
+# `journalctl -f` tails new lines and also makes historical queries
+# possible (`journalctl CONTAINER_NAME=disco --since "1 hour ago"`).
+# `docker logs` still works for the current container's lifetime under
+# the journald driver, but loses everything on `docker rm`.
 logs:
-	docker logs -f $(BOT_NAME)
+	journalctl -f CONTAINER_NAME=$(BOT_NAME)
 
 stop:
 	-docker stop $(BOT_NAME)

--- a/docs/delulu-usage.md
+++ b/docs/delulu-usage.md
@@ -343,7 +343,7 @@ propagate after the bot starts. If it's been longer than ~10
 minutes and commands still aren't showing:
 
 ```bash
-ssh root@<droplet> 'docker logs disco 2>&1 | grep commands.'
+ssh root@<droplet> 'journalctl CONTAINER_NAME=disco --since "1 hour ago" | grep commands.'
 ```
 
 Look for `commands.registered count=6` and `commands.synced
@@ -369,7 +369,16 @@ make -C apps/delulu_discord deploy
 If the container is running but not responding, tail the logs:
 
 ```bash
-docker logs -f disco
+make -C apps/delulu_discord logs
+# or directly: journalctl -f CONTAINER_NAME=disco
+```
+
+For a post-mortem after the container has been restarted (e.g.
+investigating a cancellation that happened hours ago), query
+journald with a time window — the logs survive `docker rm`:
+
+```bash
+journalctl CONTAINER_NAME=disco --since "2026-05-05 15:50" --until "2026-05-05 15:56"
 ```
 
 Anything from a failed Modal dispatch (OAuth issues, sandbox
@@ -402,5 +411,8 @@ under "Out of scope — park for v2":
 - **Architecture questions** → [`ARCHITECTURE.md`](../ARCHITECTURE.md)
 - **Deployment questions** → [`README.md`](../README.md)
 - **Design decisions** → the PRDs under [`prd/`](../prd/)
-- **Anything going wrong** → `docker logs disco` on the droplet is
-  the single best source of truth for what the bot is doing
+- **Anything going wrong** → `journalctl -f CONTAINER_NAME=disco` on
+  the droplet (or `make -C apps/delulu_discord logs`) is the single
+  best source of truth for what the bot is doing. The bot ships
+  stdout/stderr to systemd-journald so logs survive container
+  rebuilds — query historical windows with `--since` / `--until`

--- a/prd/cancel-run.md
+++ b/prd/cancel-run.md
@@ -276,7 +276,7 @@ Ship in two commits so each is independently useful and revertable:
   click cancel, verify:
   - Status message freezes with `🛑 Cancelled` footer
   - No final message appears
-  - `docker logs disco` shows `dispatch.cancelled session_id=...`
+  - `journalctl CONTAINER_NAME=disco` shows `dispatch.cancelled session_id=...`
   - Modal dashboard shows the invocation cancelled (not timed out)
 
 Split this way, the behavioral change (task tracking, cancel path)


### PR DESCRIPTION
## Summary

- Move the disco container from Docker's default json-file log driver to `--log-driver=journald` so logs survive `docker rm` and host reboots — `make deploy` no longer wipes the bot's history, which previously made post-mortems impossible across rebuilds.
- `make logs` now invokes `journalctl -f CONTAINER_NAME=$(BOT_NAME)`. `docker logs disco` still works for the current container; historical windows are queried via `journalctl CONTAINER_NAME=disco --since "…"`.
- Update README, `docs/delulu-usage.md`, and `prd/cancel-run.md` to point at the new query syntax.

## Operational note

The flag only takes effect on the next `docker run`, so after merge, run **`make -C apps/delulu_discord deploy`** on the droplet once for the change to apply. Confirmed `/var/log/journal/` already exists on the droplet, so persistence works without further setup.

## Test plan

- [ ] After deploy, `docker inspect disco --format '{{.HostConfig.LogConfig.Type}}'` reports `journald`
- [ ] `journalctl CONTAINER_NAME=disco --since "5 minutes ago"` shows the bot's startup lines (`commands.registered`, `bot.ready`)
- [ ] `make -C apps/delulu_discord logs` tails new lines
- [ ] Force a rebuild (`make -C apps/delulu_discord deploy` a second time) and confirm pre-rebuild log lines are still queryable via `journalctl --since`

🤖 Generated with [Claude Code](https://claude.com/claude-code)