### PR TITLE
ci: auto-resolve bot's prior review threads on new review submission

### DIFF
--- a/.github/workflows/auto-resolve-bot-review-threads.yml
+++ b/.github/workflows/auto-resolve-bot-review-threads.yml
@@ -1,0 +1,131 @@
+name: Auto-resolve bot review threads
+
+# Branch protection requires every conversation to be resolved
+# before merge. Coding-agent reviewers (claude[bot],
+# codex-code-reviewer[bot], etc.) post fresh reviews on every
+# push, but their PRIOR inline-comment threads stay open until
+# someone clicks Resolve in the UI. With multiple bots × multiple
+# pushes that's a lot of manual clicking.
+#
+# When a bot submits a NEW review, this workflow walks every
+# unresolved thread on the PR that:
+#   - was authored by the same bot, AND
+#   - was created BEFORE the new review's submitted_at
+# and resolves it via the GraphQL `resolveReviewThread` mutation.
+# The createdAt filter is what keeps the new review's brand-new
+# threads safe (they're younger than submitted_at).
+#
+# Bot-agnostic: works for any reviewer whose login ends in
+# `[bot]` or whose user.type is "Bot". Doesn't touch human
+# reviewers — their resolution is always a deliberate human act.
+#
+# Auth: uses the default GITHUB_TOKEN. The resolve action shows
+# in the audit log under github-actions[bot] rather than the
+# original reviewer, but resolveReviewThread only requires
+# `pull-requests: write` and the resolution itself is what
+# matters; provenance of the click is secondary.
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+# Workflow-level concurrency: serialize per-PR so two simultaneous
+# bot reviews (e.g. claude + codex on the same push) don't race
+# the GraphQL resolve mutations against each other. Cheap to
+# serialize — the whole job runs in seconds.
+concurrency:
+  group: auto-resolve-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve bot's prior threads
+    # Only run when the reviewer is a bot. Belt-and-suspenders:
+    # check both the [bot] suffix on the login (covers GitHub
+    # App installations like claude[bot] / codex-code-reviewer[bot])
+    # AND the .user.type field (would cover legacy bots that
+    # don't carry the suffix). Either signal is enough.
+    if: >-
+      github.event.review.state != 'DISMISSED'
+      && (endsWith(github.event.review.user.login, '[bot]')
+          || github.event.review.user.type == 'Bot')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Resolve prior threads from this reviewer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.pull_request.number }}
+          REVIEWER_LOGIN: ${{ github.event.review.user.login }}
+          REVIEW_AT: ${{ github.event.review.submitted_at }}
+        run: |
+          set -euo pipefail
+
+          echo "Reviewer: $REVIEWER_LOGIN"
+          echo "Review submitted_at: $REVIEW_AT"
+          echo "Looking for unresolved threads on PR #$PR authored by $REVIEWER_LOGIN before $REVIEW_AT"
+
+          # GraphQL: pull every review thread on the PR with the
+          # first comment's author + createdAt. We page once at
+          # 100 (PRs with > 100 review threads are rare; if it
+          # ever matters we'd need cursor-based paging).
+          THREADS_JSON=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      id
+                      isResolved
+                      comments(first: 1) {
+                        nodes { author { login } createdAt }
+                      }
+                    }
+                  }
+                }
+              }
+            }' \
+            -F owner="$OWNER" \
+            -F repo="$REPO" \
+            -F pr="$PR")
+
+          # Filter:
+          #   - unresolved
+          #   - authored by the new review's user
+          #   - first comment older than the new review (so we
+          #     never resolve threads the new review just opened)
+          IDS=$(echo "$THREADS_JSON" | jq -r \
+            --arg login "$REVIEWER_LOGIN" \
+            --arg at "$REVIEW_AT" '
+              .data.repository.pullRequest.reviewThreads.nodes[]
+              | select(.isResolved == false)
+              | select(.comments.nodes[0].author.login == $login)
+              | select(.comments.nodes[0].createdAt < $at)
+              | .id')
+
+          if [ -z "$IDS" ]; then
+            echo "No prior threads to resolve."
+            exit 0
+          fi
+
+          OK=0
+          FAIL=0
+          while IFS= read -r THREAD_ID; do
+            [ -z "$THREAD_ID" ] && continue
+            if gh api graphql -f query='
+                mutation($id: ID!) {
+                  resolveReviewThread(input: {threadId: $id}) {
+                    thread { isResolved }
+                  }
+                }' -f id="$THREAD_ID" >/dev/null 2>&1; then
+              OK=$((OK + 1))
+            else
+              FAIL=$((FAIL + 1))
+              echo "warning: failed to resolve thread $THREAD_ID"
+            fi
+          done <<< "$IDS"
+
+          echo "Resolved $OK prior thread(s); $FAIL failure(s)."

--- a/.github/workflows/auto-resolve-bot-review-threads.yml
+++ b/.github/workflows/auto-resolve-bot-review-threads.yml
@@ -60,54 +60,104 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           PR: ${{ github.event.pull_request.number }}
           REVIEWER_LOGIN: ${{ github.event.review.user.login }}
-          REVIEW_AT: ${{ github.event.review.submitted_at }}
+          # The GraphQL Node ID of the review that just fired this
+          # workflow. Used to exclude threads that belong to THIS
+          # review so we don't resolve them right after they post.
+          # (Codex flagged that filtering by createdAt was unsafe:
+          # a review's own comments can have createdAt earlier than
+          # the review's submitted_at because the comments are
+          # created as part of the review before the submitted
+          # event delivers. Node-ID equality is the unambiguous
+          # way to identify "did this comment come with this very
+          # review.")
+          REVIEW_NODE_ID: ${{ github.event.review.node_id }}
         run: |
           set -euo pipefail
 
           echo "Reviewer: $REVIEWER_LOGIN"
-          echo "Review submitted_at: $REVIEW_AT"
-          echo "Looking for unresolved threads on PR #$PR authored by $REVIEWER_LOGIN before $REVIEW_AT"
+          echo "Looking for unresolved threads on PR #$PR authored by $REVIEWER_LOGIN that are NOT part of review $REVIEW_NODE_ID"
 
-          # GraphQL: pull every review thread on the PR with the
-          # first comment's author + createdAt. We page once at
-          # 100 (PRs with > 100 review threads are rare; if it
-          # ever matters we'd need cursor-based paging).
-          THREADS_JSON=$(gh api graphql -f query='
-            query($owner: String!, $repo: String!, $pr: Int!) {
-              repository(owner: $owner, name: $repo) {
-                pullRequest(number: $pr) {
-                  reviewThreads(first: 100) {
-                    nodes {
-                      id
-                      isResolved
-                      comments(first: 1) {
-                        nodes { author { login } createdAt }
+          # Page through reviewThreads with cursor-based pagination
+          # — claude flagged that hard-coding `first: 100` could
+          # silently drop matches on large PRs. Each page's matching
+          # IDs land in $IDS_FILE; the resolve loop walks the file
+          # at the end.
+          IDS_FILE="$RUNNER_TEMP/threads-to-resolve.txt"
+          : > "$IDS_FILE"
+
+          CURSOR=""
+          PAGE=0
+          while : ; do
+            PAGE=$((PAGE + 1))
+
+            if [ -z "$CURSOR" ]; then
+              AFTER_CLAUSE=""
+            else
+              AFTER_CLAUSE=", after: \"$CURSOR\""
+            fi
+
+            # The query is built inline because gh api -F doesn't
+            # bind a `null` cursor cleanly across both first-page
+            # and subsequent-page calls. The cursor value is
+            # opaque base64 with no shell-special chars so direct
+            # interpolation is safe.
+            PAGE_JSON=$(gh api graphql -f query="
+              query(\$owner: String!, \$repo: String!, \$pr: Int!) {
+                repository(owner: \$owner, name: \$repo) {
+                  pullRequest(number: \$pr) {
+                    reviewThreads(first: 100${AFTER_CLAUSE}) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes {
+                        id
+                        isResolved
+                        comments(first: 1) {
+                          nodes {
+                            author { login }
+                            pullRequestReview { id }
+                          }
+                        }
                       }
                     }
                   }
                 }
-              }
-            }' \
-            -F owner="$OWNER" \
-            -F repo="$REPO" \
-            -F pr="$PR")
+              }" \
+              -F owner="$OWNER" \
+              -F repo="$REPO" \
+              -F pr="$PR")
 
-          # Filter:
-          #   - unresolved
-          #   - authored by the new review's user
-          #   - first comment older than the new review (so we
-          #     never resolve threads the new review just opened)
-          IDS=$(echo "$THREADS_JSON" | jq -r \
-            --arg login "$REVIEWER_LOGIN" \
-            --arg at "$REVIEW_AT" '
-              .data.repository.pullRequest.reviewThreads.nodes[]
-              | select(.isResolved == false)
-              | select(.comments.nodes[0].author.login == $login)
-              | select(.comments.nodes[0].createdAt < $at)
-              | .id')
+            # Filter on this page:
+            #   - thread is unresolved
+            #   - first comment exists AND its author login matches
+            #     the reviewer (null-safe: ghost/deleted accounts
+            #     yield .author == null which would otherwise error
+            #     under set -e and kill the entire resolve step)
+            #   - first comment's review is NOT the one that just
+            #     fired this workflow (so we never resolve the
+            #     new review's own brand-new threads)
+            echo "$PAGE_JSON" | jq -r \
+              --arg login "$REVIEWER_LOGIN" \
+              --arg review_id "$REVIEW_NODE_ID" '
+                .data.repository.pullRequest.reviewThreads.nodes[]
+                | select(.isResolved == false)
+                | select((.comments.nodes[0].author? // null) != null)
+                | select(.comments.nodes[0].author.login == $login)
+                | select((.comments.nodes[0].pullRequestReview.id // "") != $review_id)
+                | .id' \
+              >> "$IDS_FILE"
 
-          if [ -z "$IDS" ]; then
-            echo "No prior threads to resolve."
+            HAS_NEXT=$(echo "$PAGE_JSON" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+            CURSOR=$(echo "$PAGE_JSON" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty')
+
+            if [ "$HAS_NEXT" != "true" ] || [ -z "$CURSOR" ]; then
+              break
+            fi
+          done
+
+          MATCH_COUNT=$(wc -l < "$IDS_FILE" | tr -d ' ')
+          echo "Walked $PAGE page(s); $MATCH_COUNT thread(s) to resolve."
+
+          if [ "$MATCH_COUNT" -eq 0 ]; then
+            echo "Nothing to do."
             exit 0
           fi
 
@@ -126,6 +176,6 @@ jobs:
               FAIL=$((FAIL + 1))
               echo "warning: failed to resolve thread $THREAD_ID"
             fi
-          done <<< "$IDS"
+          done < "$IDS_FILE"
 
           echo "Resolved $OK prior thread(s); $FAIL failure(s)."

--- a/.github/workflows/auto-resolve-bot-review-threads.yml
+++ b/.github/workflows/auto-resolve-bot-review-threads.yml
@@ -63,14 +63,23 @@ jobs:
           # The GraphQL Node ID of the review that just fired this
           # workflow. Used to exclude threads that belong to THIS
           # review so we don't resolve them right after they post.
-          # (Codex flagged that filtering by createdAt was unsafe:
-          # a review's own comments can have createdAt earlier than
-          # the review's submitted_at because the comments are
-          # created as part of the review before the submitted
-          # event delivers. Node-ID equality is the unambiguous
-          # way to identify "did this comment come with this very
-          # review.")
+          # (Codex flagged that filtering by createdAt alone was
+          # unsafe: a review's own comments can have createdAt
+          # earlier than the review's submitted_at because the
+          # comments are created as part of the review before the
+          # submitted event delivers. Node-ID equality is the
+          # unambiguous "this thread belongs to this very review.")
           REVIEW_NODE_ID: ${{ github.event.review.node_id }}
+          # Used as a SECONDARY filter alongside the Node-ID
+          # exclusion to defend against a delayed-run race: if a
+          # same-bot review B lands AFTER review A but this
+          # workflow processes A's webhook later, Node-ID alone
+          # would let A's run resolve B's threads (B's threadId
+          # != A's review.id, so the exclusion misses it). The
+          # createdAt cutoff says "only resolve threads opened
+          # before A was submitted" — independent of which review
+          # they belong to.
+          REVIEW_SUBMITTED_AT: ${{ github.event.review.submitted_at }}
         run: |
           set -euo pipefail
 
@@ -101,6 +110,12 @@ jobs:
             # and subsequent-page calls. The cursor value is
             # opaque base64 with no shell-special chars so direct
             # interpolation is safe.
+            # Pull up to 50 comments per thread so the
+            # human-participation check below has enough context.
+            # Threads with > 50 comments are vanishingly rare in
+            # practice; on the off chance one exists, conservative
+            # behavior (don't resolve) kicks in via the "all
+            # commenters are bots" check below.
             PAGE_JSON=$(gh api graphql -f query="
               query(\$owner: String!, \$repo: String!, \$pr: Int!) {
                 repository(owner: \$owner, name: \$repo) {
@@ -110,8 +125,10 @@ jobs:
                       nodes {
                         id
                         isResolved
-                        comments(first: 1) {
+                        comments(first: 50) {
+                          totalCount
                           nodes {
+                            createdAt
                             author { login }
                             pullRequestReview { id }
                           }
@@ -131,17 +148,43 @@ jobs:
             #     the reviewer (null-safe: ghost/deleted accounts
             #     yield .author == null which would otherwise error
             #     under set -e and kill the entire resolve step)
+            #   - thread has NO non-bot replies — if a human chimed
+            #     in we leave the thread alone regardless of who
+            #     started it. Identifies bots by `[bot]` suffix on
+            #     the login (covers GitHub Apps and the legacy
+            #     github-actions[bot]). Conservative: anything that
+            #     looks human-ish stays open.
+            #   - we only saw the first 50 comments; if the thread
+            #     was longer, conservatively leave it alone. We
+            #     don't know what's beyond and the cost of skipping
+            #     a stale thread is one manual click; the cost of
+            #     auto-resolving a live thread is dropping context.
             #   - first comment's review is NOT the one that just
             #     fired this workflow (so we never resolve the
             #     new review's own brand-new threads)
+            #   - first comment's createdAt < this review's
+            #     submitted_at (defense against the delayed-run
+            #     race where a same-bot newer review's threads
+            #     would otherwise be eligible)
             echo "$PAGE_JSON" | jq -r \
               --arg login "$REVIEWER_LOGIN" \
-              --arg review_id "$REVIEW_NODE_ID" '
+              --arg review_id "$REVIEW_NODE_ID" \
+              --arg cutoff "$REVIEW_SUBMITTED_AT" '
                 .data.repository.pullRequest.reviewThreads.nodes[]
                 | select(.isResolved == false)
                 | select((.comments.nodes[0].author? // null) != null)
                 | select(.comments.nodes[0].author.login == $login)
+                | select(.comments.totalCount <= (.comments.nodes | length))
+                | select(
+                    [.comments.nodes[]
+                     | (.author? // null)
+                     | select(. != null)
+                     | .login
+                     | endswith("[bot]")]
+                    | all
+                  )
                 | select((.comments.nodes[0].pullRequestReview.id // "") != $review_id)
+                | select(.comments.nodes[0].createdAt < $cutoff)
                 | .id' \
               >> "$IDS_FILE"
 


### PR DESCRIPTION
## Summary

Branch protection requires every conversation resolved before merge. Coding-agent reviewers post fresh reviews on every push, but their **prior** inline-comment threads stay open until someone manually clicks Resolve. With multiple bots × multiple pushes that accumulates fast (PR #76 currently has 5 unresolved Claude threads blocking merge despite both bots having approved).

This workflow listens for `pull_request_review.submitted` events from **any** bot reviewer (login ends in `[bot]` or `user.type == Bot`) and resolves the same reviewer's prior unresolved threads on the PR — filtered by `firstComment.createdAt < review.submittedAt` so the new review's brand-new threads stay safe.

## Why a separate workflow vs. extending each reviewer

- **Bot-agnostic**: handles `claude[bot]`, `codex-code-reviewer[bot]`, and any future bot without per-reviewer wiring
- **Triggered by the right event**: `pull_request_review.submitted` fires exactly once per submitted review, vs. having each reviewer's workflow do its own cleanup
- **Default `GITHUB_TOKEN`**: no extra secrets; `pull-requests: write` is enough

## Effect on existing PRs

For PR #76's 5 currently-unresolved Claude threads: this workflow doesn't retroactively run on past reviews. Two options:

1. **Manually resolve once** in the UI (5 clicks)
2. **Push any commit** to PR #76 → Claude re-reviews → this workflow fires → all of Claude's prior threads auto-resolve

After this lands, both bots' future PRs auto-clean themselves.

## Test plan
- [ ] CI on this PR: workflow has nothing to do (no prior bot threads on this brand-new PR), but it should successfully install and pass syntax/lint checks
- [ ] Post-merge: push an empty commit to PR #76 → Claude re-reviews → 5 stale threads auto-resolve

## Coexistence with PR #76

PR #76's `codex-code-review.yml` has codex-specific snapshot/resolve steps that this workflow now largely supersedes. Leaving the codex-specific in place as defense in depth (idempotent on already-resolved threads). Future cleanup PR can remove them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)