### PR TITLE
ci: fix both review bots — Codex OPENAI_API_KEY auth + reliable Claude submit

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -89,28 +89,18 @@ all of these bars:**
 If you are not certain an issue is real, **do not include it.**
 False positives erode trust.
 
-## Step 5 — Write the review payload
+## Step 5 — Write the review payload as ONE JSON file
 
-Use the `Write` tool for both files. **Do not use shell heredoc.**
-
-### 5a — Summary body (`/tmp/review.md`)
-
-```markdown
-## Review summary
-
-<one-sentence verdict: "LGTM" or "minor non-blocking notes" (both
-approve) — or "flagging N issue(s) for human review" (comment)>
-
-## Deployment
-
-<which side(s) need a redeploy/rebuild, if any. Skip if the PR
-doesn't touch either app.>
-```
-
-### 5b — Inline comments (`/tmp/review_comments.json`)
+Use the `Write` tool (never shell heredoc) to create a single
+`/tmp/review.json` holding the **entire** Reviews API body — `event`,
+`body`, and `comments` together. It must be one file: GitHub needs
+`event` *in the request body*, and the submit step sends this file as
+the whole body (Step 6 explains why splitting it silently breaks).
 
 ```json
 {
+  "event": "APPROVE",
+  "body": "## Review summary\n\n<verdict>\n\n## Deployment\n\n<which side needs a rebuild/redeploy, if any — omit this line when neither app is touched>",
   "comments": [
     {
       "path": "relative/file/path.py",
@@ -121,49 +111,44 @@ doesn't touch either app.>
 }
 ```
 
-- `path` — relative to repo root, must match the diff path exactly.
-- `line` — line number in the **new version** of the file. Must be
-  a line visible in the diff (added or context line within a hunk).
-  For ranges, use the last line.
-- `body` — prefix with the category. Keep it specific and actionable.
-
-If there are no findings, write `{"comments": []}`.
+- `event` — `APPROVE` or `COMMENT` (never `REQUEST_CHANGES`); pick per
+  Step 6.
+- `body` — the summary as a JSON string (escape newlines as `\n`).
+  Verdict: `"LGTM"` / `"minor non-blocking notes"` (both approve) or
+  `"flagging N issue(s) for human review"` (comment).
+- `comments` — inline findings, or `[]` if none. Each: `path`
+  (repo-relative, matches the diff exactly), `line` (line number in the
+  NEW file, visible in a diff hunk; last line for a range), `body`
+  (prefix with the category).
 
 ## Step 6 — Submit exactly one review
 
 **Advisory only — never `REQUEST_CHANGES`.**
 
 **Default to APPROVE.** `main` requires approving reviews, so a clean
-review that only leaves a COMMENT forces a needless human
-self-approval. Decide the event from your *findings*, not your tone:
+review that only COMMENTs forces a needless human self-approval. Set
+`"event"` from your *findings*, not your tone:
 
-- **APPROVE** — `/tmp/review_comments.json` has zero inline findings
-  **and** the body raises no blocking concern. "LGTM" and "minor
-  non-blocking notes" both approve.
+- **APPROVE** — `comments` is `[]` **and** the body raises no blocking
+  concern. "LGTM" and "minor non-blocking notes" both approve.
 - **COMMENT** — there is at least one inline finding, **or** you are
   putting a substantive concern a human must weigh in the body.
 
-Derive the event from the findings file so the choice isn't left to
-tone, then submit one atomic review:
+Submit with a **single `gh api` command**. Two hard rules, each of which
+has silently eaten a review before:
+
+1. It MUST start with `gh api` — the sandbox only allows
+   `Bash(gh api:*)` and rejects anything it can't statically analyze:
+   no leading `VAR=...` assignment, no `$(...)`, no `jq`/`cat` pipeline.
+2. It MUST send the whole payload via `--input` with **no `-f`/`-F`
+   field flags**. With `--input`, any `-f`/`-F` flags are pushed to the
+   query string instead of the body, so `event` is dropped and GitHub
+   creates an unsubmitted **pending** review that never appears.
 
 ```bash
-REVIEW_BODY=$(cat /tmp/review.md)
-if [ "$(jq '.comments | length' /tmp/review_comments.json)" -eq 0 ]; then
-  EVENT=APPROVE   # nothing flagged inline → approve. Override to
-                  # COMMENT only if REVIEW_BODY raises a blocking concern.
-else
-  EVENT=COMMENT
-fi
-gh api \
-  "repos/{owner}/{repo}/pulls/<N>/reviews" \
-  --method POST \
-  -f event="$EVENT" \
-  -f body="$REVIEW_BODY" \
-  --input /tmp/review_comments.json \
-  --jq '.html_url'
+gh api "repos/{owner}/{repo}/pulls/<N>/reviews" --method POST --input /tmp/review.json --jq '.html_url'
 ```
 
-**Never retry on failure.** One attempt, one outcome.
-
-**Only fallback:** if `APPROVE` fails with "cannot approve your own
-pull request", retry once with `event=COMMENT` using the same body.
+**One attempt, one outcome — never retry**, with one exception: if it
+fails with "cannot approve your own pull request", change `"event"` to
+`"COMMENT"` in `/tmp/review.json` and run the command once more.

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -277,6 +277,10 @@ jobs:
         run: |
           set -euo pipefail
 
+          # The droplet Restore step creates CODEX_HOME, but it's skipped
+          # in API-key mode — ensure the dir exists either way.
+          mkdir -p "$CODEX_HOME"
+
           OUT_FILE="$RUNNER_TEMP/codex-output.txt"
 
           # CODEX_HOME comes from the workflow-level env block.

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -1,8 +1,13 @@
 name: Codex Code Review
 
-# Reviews each PR via the OpenAI Codex CLI authenticated against the
-# repo owner's ChatGPT account (NOT an OPENAI_API_KEY). Cost lives on
-# the ChatGPT plan rather than per-token API billing.
+# Reviews each PR via the OpenAI Codex CLI. Two auth modes, chosen by
+# the "Decide auth mode" step:
+#   - If the OPENAI_API_KEY secret is set → API-key auth (OpenAI's
+#     recommended CI auth: static key, no rotating refresh token, no
+#     droplet, no sibling-client breakage; metered per-token billing).
+#   - Otherwise → the repo owner's ChatGPT account via auth.json,
+#     billed on the ChatGPT plan. That path is described below; it
+#     needs the droplet/secret token plumbing the API-key path skips.
 #
 # Auth lifecycle (see prd/codex-ci-auth.md for the full design):
 #
@@ -89,7 +94,28 @@ jobs:
             "$PR_BASE_REF" \
             "+refs/pull/$PR_NUMBER/head"
 
+      - name: Decide auth mode
+        # If the OPENAI_API_KEY secret is set, authenticate with it
+        # (OpenAI's recommended CI auth — static key, no rotating
+        # refresh token, no droplet, no sibling-client breakage). Else
+        # fall back to the ChatGPT-account auth.json path below. Fork
+        # PRs don't receive secrets, so an untrusted external PR sees
+        # neither credential and simply soft-skips.
+        id: auth_mode
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "${OPENAI_API_KEY:-}" ]; then
+            echo "mode=apikey" >> "$GITHUB_OUTPUT"
+            echo "Auth mode: API key (OPENAI_API_KEY set) — droplet auth.json not used."
+          else
+            echo "mode=chatgpt" >> "$GITHUB_OUTPUT"
+            echo "Auth mode: ChatGPT account (auth.json via droplet/secret)."
+          fi
+
       - name: Set up SSH key for droplet
+        if: steps.auth_mode.outputs.mode == 'chatgpt'
         env:
           DROPLET_HOST: ${{ secrets.DROPLET_HOST }}
           DROPLET_SSH_KEY: ${{ secrets.DROPLET_SSH_KEY }}
@@ -110,6 +136,7 @@ jobs:
           ssh-keyscan -H "$DROPLET_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
       - name: Restore auth.json (droplet → fallback to secret seed)
+        if: steps.auth_mode.outputs.mode == 'chatgpt'
         env:
           DROPLET_HOST: ${{ secrets.DROPLET_HOST }}
           # The secret is only read if the droplet copy is missing.
@@ -194,6 +221,11 @@ jobs:
       - name: Run Codex
         id: run_codex
         env:
+          # When set, codex authenticates with this API key instead of
+          # the ChatGPT auth.json. Arrives as "" when the secret is
+          # unset; the run step drops an empty value so it can never
+          # shadow the auth.json path.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PROMPT: |
             You are reviewing PR #${{ github.event.pull_request.number }}
             for ${{ github.repository }}.
@@ -289,13 +321,30 @@ jobs:
           # tell an expired-auth failure (a credential outage that must
           # NOT red-block every PR) apart from a genuine review failure.
           CODEX_LOG="$RUNNER_TEMP/codex-run.log"
+
+          # An empty OPENAI_API_KEY (secret unset) must not shadow the
+          # auth.json path — drop it so codex falls through to the
+          # ChatGPT bundle.
+          if [ -z "${OPENAI_API_KEY:-}" ]; then unset OPENAI_API_KEY || true; fi
+
           set +e
-          codex exec \
-            --skip-git-repo-check \
-            --sandbox workspace-write \
-            --model gpt-5.5 \
-            --output-last-message "$OUT_FILE" \
-            "$PROMPT" 2>&1 | tee "$CODEX_LOG"
+          if [ -n "${OPENAI_API_KEY:-}" ]; then
+            # API-key auth: no `--model gpt-5.5` pin — that model is
+            # ChatGPT-account-only. Let codex auto-select a model the
+            # API key can use (e.g. gpt-5.1-codex-max).
+            codex exec \
+              --skip-git-repo-check \
+              --sandbox workspace-write \
+              --output-last-message "$OUT_FILE" \
+              "$PROMPT" 2>&1 | tee "$CODEX_LOG"
+          else
+            codex exec \
+              --skip-git-repo-check \
+              --sandbox workspace-write \
+              --model gpt-5.5 \
+              --output-last-message "$OUT_FILE" \
+              "$PROMPT" 2>&1 | tee "$CODEX_LOG"
+          fi
           RC=${PIPESTATUS[0]}
           set -e
 
@@ -314,6 +363,10 @@ jobs:
               # the job still succeeds (no review posted, no red check).
               exit 0
             fi
+            if [ -n "${OPENAI_API_KEY:-}" ]; then
+              echo "::warning title=Codex (API-key) review failed::codex exec exited $RC under OPENAI_API_KEY auth; skipped WITHOUT blocking the PR. Check the key / model availability in the log above."
+              exit 0
+            fi
             echo "::error::codex exec failed (exit $RC) for a non-auth reason; see the log above."
             exit 1
           fi
@@ -330,10 +383,11 @@ jobs:
           echo "output-file=$OUT_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Persist refreshed auth.json back to droplet
-        # `if: always()` so we still upload a refresh even when codex
-        # exec errors mid-run — the refresh might be the very thing
-        # that would unbreak the next run.
-        if: always()
+        # `always()` so we still upload a refresh even when codex exec
+        # errors mid-run. Gated to ChatGPT mode — under API-key auth
+        # there's no auth.json (and possibly no droplet secrets) to
+        # persist.
+        if: ${{ always() && steps.auth_mode.outputs.mode == 'chatgpt' }}
         env:
           DROPLET_HOST: ${{ secrets.DROPLET_HOST }}
         run: |

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -349,7 +349,7 @@ jobs:
             codex exec \
               --skip-git-repo-check \
               --sandbox workspace-write \
-              --model "${CODEX_API_MODEL:-gpt-5-codex}" \
+              --model "${CODEX_API_MODEL:-gpt-4.1}" \
               --output-last-message "$OUT_FILE" \
               "$PROMPT" 2>&1 | tee -a "$CODEX_LOG"
           else

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -349,7 +349,7 @@ jobs:
             codex exec \
               --skip-git-repo-check \
               --sandbox workspace-write \
-              --model "${CODEX_API_MODEL:-gpt-5.1-codex-max}" \
+              --model "${CODEX_API_MODEL:-gpt-5-codex}" \
               --output-last-message "$OUT_FILE" \
               "$PROMPT" 2>&1 | tee -a "$CODEX_LOG"
           else

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -226,6 +226,10 @@ jobs:
           # unset; the run step drops an empty value so it can never
           # shadow the auth.json path.
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # Optional override for the API-key model pin (default
+          # gpt-5.1-codex-max) if this OpenAI project entitles a
+          # different codex model.
+          CODEX_API_MODEL: ${{ vars.CODEX_API_MODEL }}
           PROMPT: |
             You are reviewing PR #${{ github.event.pull_request.number }}
             for ${{ github.repository }}.
@@ -338,11 +342,14 @@ jobs:
             # (you get a 401 "Missing bearer" otherwise) — write the key
             # into CODEX_HOME first. `--with-api-key` reads it from stdin.
             printenv OPENAI_API_KEY | codex login --with-api-key >>"$CODEX_LOG" 2>&1
-            # No `--model gpt-5.5` pin — that model is ChatGPT-account-
-            # only; let codex pick an API-compatible default.
+            # codex's default `gpt-5.5` is ChatGPT-account-only ("project
+            # does not have access"). Pin a codex model the API project
+            # can use. Override via the CODEX_API_MODEL repo variable if
+            # this project has a different model entitlement.
             codex exec \
               --skip-git-repo-check \
               --sandbox workspace-write \
+              --model "${CODEX_API_MODEL:-gpt-5.1-codex-max}" \
               --output-last-message "$OUT_FILE" \
               "$PROMPT" 2>&1 | tee -a "$CODEX_LOG"
           else

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -331,23 +331,27 @@ jobs:
           # ChatGPT bundle.
           if [ -z "${OPENAI_API_KEY:-}" ]; then unset OPENAI_API_KEY || true; fi
 
+          : > "$CODEX_LOG"
           set +e
           if [ -n "${OPENAI_API_KEY:-}" ]; then
-            # API-key auth: no `--model gpt-5.5` pin — that model is
-            # ChatGPT-account-only. Let codex auto-select a model the
-            # API key can use (e.g. gpt-5.1-codex-max).
+            # `codex exec` does NOT read OPENAI_API_KEY from the env
+            # (you get a 401 "Missing bearer" otherwise) — write the key
+            # into CODEX_HOME first. `--with-api-key` reads it from stdin.
+            printenv OPENAI_API_KEY | codex login --with-api-key >>"$CODEX_LOG" 2>&1
+            # No `--model gpt-5.5` pin — that model is ChatGPT-account-
+            # only; let codex pick an API-compatible default.
             codex exec \
               --skip-git-repo-check \
               --sandbox workspace-write \
               --output-last-message "$OUT_FILE" \
-              "$PROMPT" 2>&1 | tee "$CODEX_LOG"
+              "$PROMPT" 2>&1 | tee -a "$CODEX_LOG"
           else
             codex exec \
               --skip-git-repo-check \
               --sandbox workspace-write \
               --model gpt-5.5 \
               --output-last-message "$OUT_FILE" \
-              "$PROMPT" 2>&1 | tee "$CODEX_LOG"
+              "$PROMPT" 2>&1 | tee -a "$CODEX_LOG"
           fi
           RC=${PIPESTATUS[0]}
           set -e


### PR DESCRIPTION
**Re-lands + fixes the API-key auth path so Codex actually reviews.** ✅ Verified working on this PR — Codex posted an APPROVED review via `codex-code-reviewer[bot]`.

The API-key path was part of #88 but my commit landed after the squash-merge, so `main` never got it — every Codex run used the dead ChatGPT token and soft-skipped. This re-lands it and fixes the bugs found by running it live:

1. **CODEX_HOME wasn't created** in API-key mode (the droplet Restore step that made it is skipped) → create it in Run Codex.
2. **`codex exec` ignores `OPENAI_API_KEY` from the env** (401 "Missing bearer") → `printenv OPENAI_API_KEY | codex login --with-api-key` first.
3. **codex defaults to `gpt-5.5`** (ChatGPT-account-only) → pin a model; **this OpenAI project only entitles `gpt-4.1`** (not the gpt-5 codex models), so that's the default. Override via the `CODEX_API_MODEL` repo variable if you later grant the project gpt-5-codex access.

Net: with `OPENAI_API_KEY` set (it is), Codex authenticates with a static key — no rotation, no droplet, no sibling-client treadmill — and reviews every PR. ChatGPT path unchanged when the key isn't set; API-key failures soft-skip so they never red-block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)