### PR TITLE
docs: deep-research training+eval architecture + root tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.gitignore
 checkpoint**
 minimal-llama**
 upload.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,19 @@ Each project owns its own Makefile and tooling — there is no repo-wide `poetry
 
 - **Delulu (active)** — two apps, each with its own project `CLAUDE.md`: [`apps/delulu_discord`](apps/delulu_discord/CLAUDE.md) (the bot) and [`apps/delulu_sandbox_modal`](apps/delulu_sandbox_modal/CLAUDE.md) (the Modal sandbox). Quick: `make -C apps/delulu_discord check`, `make -C apps/delulu_sandbox_modal modal-deploy`. Top-level shortcuts: `make check`, `make deploy-bot`, `make deploy-modal`, `make deploy-all`.
 - **LoRA-Instruct training**: see [`training/lora_instruct/CLAUDE.md`](training/lora_instruct/CLAUDE.md) for setup, lint, test, and training commands — they no longer live at the repo root.
+- **Deep-research training + eval** (uv-based, `make dr-check` to lint all): the shared agent/tool/reward lib [`libs/dr_agent`](libs/dr_agent/CLAUDE.md) (imported by training, eval, apps), the [`services/search_server`](services/search_server/CLAUDE.md) tool HTTP service, [`data/datagen`](data/datagen/CLAUDE.md) synthetic task generation, the [`eval`](eval/CLAUDE.md) two-phase harness, and the slime RL recipe [`training/rl_deepresearch`](training/rl_deepresearch/CLAUDE.md). Architecture + rationale: [prd/deep-research-training-eval-infra.md](prd/deep-research-training-eval-infra.md).
 
 ## Working in the monorepo
 
 The repo is category-first: `apps/` (production services), `training/`
-(reusable SFT/RLHF recipes), `data/` (cross-project datasets + scrapers),
-`infra/` (shared infra, e.g. the managed-agents platform), plus `docs/`,
-`prd/`, and an empty `libs/` slot for future cross-project packages. Most
-tasks are scoped to a single project — work from that project's directory,
-not the repo root:
+(reusable SFT/RLHF recipes), `data/` (cross-project datasets + scrapers +
+data-gen), `services/` (runtime application services, e.g. the search/tool HTTP
+server), `infra/` (shared infra/deployment, e.g. the managed-agents platform),
+`libs/` (shared cross-project packages, e.g. `dr_agent`), plus `docs/`, `prd/`,
+and `eval/` (the deep-research evaluation harness). Note `services/` (runtime
+services) is distinct from `infra/` (deployment/infrastructure). Most tasks are
+scoped to a single project — work from that project's directory, not the repo
+root:
 
 - **Identify the project first.** Almost every task lives inside one
   project (`apps/delulu_discord`, `training/lora_instruct`, …).

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-.PHONY: help check lora-check deploy-bot deploy-modal deploy-all
+.PHONY: help check lora-check dr-check deploy-bot deploy-modal deploy-all
 
 APPS := apps/delulu_discord apps/delulu_sandbox_modal
+# Deep-research training+eval projects (uv-based; see prd/deep-research-training-eval-infra.md)
+DR_PROJECTS := libs/dr_agent services/search_server data/datagen eval training/rl_deepresearch
 
 help:
 	@echo "Top-level targets:"
 	@echo "  make check         run ruff on all apps/"
 	@echo "  make lora-check    run ruff on training/lora_instruct"
+	@echo "  make dr-check      run ruff on all deep-research projects (libs/services/data/eval/training)"
 	@echo "  make deploy-bot    deploy the Discord bot to the VPS"
 	@echo "  make deploy-modal  deploy the Modal sandbox app"
 	@echo "  make deploy-all    modal-deploy then bot-deploy"
@@ -13,6 +16,7 @@ help:
 	@echo "Sub-project targets available via:"
 	@echo "  make -C apps/delulu_discord <target>"
 	@echo "  make -C apps/delulu_sandbox_modal <target>"
+	@echo "  make -C libs/dr_agent <target>   (and other DR_PROJECTS)"
 
 check:
 	$(MAKE) -C apps/delulu_discord check
@@ -20,6 +24,9 @@ check:
 
 lora-check:
 	cd training/lora_instruct && poetry run ruff check .
+
+dr-check:
+	@for p in $(DR_PROJECTS); do echo "== $$p =="; $(MAKE) -C $$p check || exit 1; done
 
 deploy-bot:
 	$(MAKE) -C apps/delulu_discord deploy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,12 @@
 
 LoRA-Instruct fine-tunes open-source causal LLMs using Low-Rank Adaptation (LoRA) via HuggingFace PEFT. It also includes an inference benchmarking tool for OpenAI-compatible endpoints. The project now lives at `training/lora_instruct/`.
 
+> **Deep-research training + evaluation infrastructure** (the slime RL recipe,
+> the shared `libs/dr_agent` library, `services/search_server`, `data/datagen`,
+> and the `eval/` harness) has its own architecture doc:
+> [plan-deep-agent-rl.md](plan-deep-agent-rl.md). The sections below describe the
+> LoRA-Instruct SFT recipe specifically.
+
 ## Directory Structure
 
 ```

--- a/docs/plan-deep-agent-rl.md
+++ b/docs/plan-deep-agent-rl.md
@@ -1,443 +1,170 @@
-# Plan: Deep Agent Training & Evaluation with Reinforcement Learning
+# Deep-research agent: training + evaluation architecture
 
-> Transforming LoRA-Instruct into a deep agent RL training and evaluation repository, with autoresearch-style autonomous experimentation.
+> SMILE-factory as full-stack infrastructure for training and evaluating a
+> **deep-research agent** (multi-turn search → read → synthesize) via RL, plus the
+> data generation and evaluation that surround it.
 
-## 1. Vision and Goals
+> **History:** this document replaces an earlier Tinker→prime-rl plan that
+> predated the monorepo reorg. The chosen RL backend is now **slime**
+> (THUDM/slime), and the layout follows the repo's category-first monorepo
+> conventions rather than the old single-project `lora_instruct/` tree. The
+> earlier "evaluation as the stable core" principle survives; the backend and
+> directory structure do not.
 
-The goal is to evolve this repository from a LoRA fine-tuning toolkit into a full-stack platform for training LLM agents via reinforcement learning (RL), then layering on Karpathy's [autoresearch](https://github.com/karpathy/autoresearch) pattern so an AI agent can autonomously experiment with RL training recipes overnight.
+## 1. Goals
 
-**Phased approach:**
+Evolve the repo into infrastructure that can:
 
-1. **Phase 1 (Now): Tinker API + Evaluation.** Use [Tinker](https://tinker-docs.thinkingmachines.ai/) (Thinking Machines' managed RL training API) to get GRPO training running fast — no local training loop to build. Focus effort on evaluation environments, reward functions, and the autoresearch experiment loop.
-2. **Phase 2 (Future): Migrate to prime-rl.** Adopt [PrimeIntellect's prime-rl](https://github.com/PrimeIntellect-ai/prime-rl) for self-hosted async RL training at scale, keeping the evaluation and autoresearch infrastructure built in Phase 1.
+1. **Train** a deep-research agent with RL (GRPO) on slime.
+2. **Evaluate** it on deep-research benchmarks with a standalone, reproducible
+   harness.
+3. **Generate** synthetic training/eval data with ground truth baked in.
+4. Do all of the above **without train/eval skew** — the agent loop, the tools,
+   and the scorers are *one shared library* used by training, eval, and serving.
 
-**Why this ordering:** Tinker handles all distributed training infrastructure (LoRA, GRPO, rollouts, optimization) via API calls, letting us validate the evaluation + autoresearch loop without writing a training loop. Once we've proven the outer loop works, we swap the training backend to prime-rl for full control and scale.
+## 2. How the design was chosen
 
----
+The layout was driven by a survey of six deep-research codebases — DR-Tulu,
+QUEST, Search-R1, DeepResearcher, StepDeepResearch, and chroma
+context-1-data-gen. The convergent patterns we adopted (and the anti-patterns we
+avoided):
 
-## 2. Current State Assessment
-
-### What we have (LoRA-Instruct)
-
-| Component | Status | Reusable? |
+| Pattern | Source | Decision |
 |---|---|---|
-| LoRA fine-tuning (`training/lora_instruct/finetune.py`) | Working | Yes — reference for SFT, eventually replaced |
-| Prompt system (`training/lora_instruct/utils/prompter.py`) | Working | Yes — extend for chat/agent templates |
-| Inference benchmarking (`training/lora_instruct/inference/bench.py`) | Working | Partially — latency metrics, not agent eval |
-| Alpaca datasets (`training/lora_instruct/dataset/`) | Working | Yes — seed SFT data |
-| DDP support | Working | Archive — Tinker/prime-rl handle distribution |
-| Notebooks | Working | Archive or adapt |
-| RL / reward modeling / agent evaluation | **Missing** | N/A |
+| Top level = pipeline stage (data → train → serve → eval) | QUEST, DR-Tulu | **Adopt** |
+| One shared agent+tool library, reused as RL env **and** eval/serve runtime | DR-Tulu `dr-agent-lib`, StepFun `cortex` | **Adopt — the linchpin** |
+| Tools as an HTTP service behind one contract, own dep env | Search-R1, DeepResearcher, QUEST (FAISS) | **Adopt** (`services/search_server`) |
+| Reward = flat per-task registry, dispatched by `data_source` | Search-R1, DR-Tulu | **Adopt** (`dr_agent.rewards`) |
+| Two-phase eval: generate rollouts → JSON → score offline | DeepResearcher, StepFun | **Adopt** (`eval/`) |
+| One folder per benchmark + shared `samplers/` | DR-Tulu, QUEST | **Adopt** |
+| `core/` base + `domains/<name>/` subclasses for data-gen | chroma | **Adopt** (`data/datagen`) |
+| Vendoring the whole RL engine into the tree | Search-R1, DeepResearcher, DR-Tulu | **Avoid** — slime is a pinned Docker image |
+| Tool code duplicated 3–4× across stages | QUEST | **Avoid** — `libs/` is the single source |
+| Hyperparameters in giant `.sh` override blobs | most | **Avoid** — versioned YAML configs |
+| Prompts hardcoded in Python | StepFun, chroma | **Avoid** — templates under `prompts/` |
 
-### External systems we'll integrate
+## 3. Layout
 
-| System | Role | Phase |
+Category-first, one project per directory (each owns its `pyproject.toml`,
+`Makefile`, `CLAUDE.md`; uv + hatchling + `src/` layout):
+
+```
+libs/dr_agent/              shared agent loop + tools + reward registry + prompts
+                           (imported by training, eval, apps — the only legal
+                            cross-project import surface)
+services/search_server/     tool/search HTTP service (/search /retrieve /visit);
+                           heavy retrieval deps (bm25/faiss) isolated here
+data/datagen/               core/ stage base-classes + domains/<name>/ pipelines;
+                           output conforms to the dr_agent scoring schema
+eval/                       standalone two-phase harness (generate → score);
+                           benchmarks/<name>/ + shared samplers/
+training/rl_deepresearch/   thin slime recipe: plugins/ (rollout + reward),
+                           configs/ (YAML), launch/, engine/ (README only)
+training/lora_instruct/     existing SFT recipe (poetry) — unchanged
+```
+
+Data flow:
+
+```
+data/datagen ──tasks(jsonl, w/ ground truth)──► training/rl_deepresearch ──► policy
+       │                                              │  (slime: Megatron+SGLang)
+       │                                              ▼
+       └──────────────────────────────────────► eval/ (generate → score)
+                          both call ▲
+                                    │
+                       libs/dr_agent (agent loop + tools + rewards)
+                                    │
+                       services/search_server (HTTP tools)
+```
+
+## 4. Key decisions
+
+### 4.1 One shared library (`libs/dr_agent`) — no train/eval skew
+The agent loop, tools, prompts, and reward scorers live once and are imported by
+training (RL env + reward), eval (rollout + scoring), and apps (serving). The
+surveyed repos that skipped this duplicated tools and drifted; the ones that
+built it are the ones worth copying. Per the root CLAUDE.md, `libs/` is the only
+sanctioned cross-project import surface, so this is on-convention.
+
+### 4.2 Reward = one registry, dispatched by `data_source`
+`dr_agent.rewards.score(row)` looks up a scorer by the row's `data_source` tag.
+RL reward (`plugins/reward.py`) and eval scoring (`harness/score.py`) both call
+it. Add a task type = add one scorer file + register it. Currently `exact_match`
+and `f1` are implemented; `rubric` and `citation` are TODO.
+
+### 4.3 `eval/` is standalone and two-phase
+Generate rollouts → JSON, then score offline. Decoupling makes re-scoring cheap
+and auditable, and forces eval to use the *same* agent loop + scorers as
+training. Search-R1/DeepResearcher folded eval into the trainer (val batches +
+reward); that makes eval irreproducible outside a training run — we don't.
+
+### 4.4 Tools are an HTTP service in `services/`
+`services/search_server` exposes `/search`, `/retrieve`, `/visit` behind a stable
+contract. Heavy retrieval deps (bm25/faiss/sentence-transformers) stay out of the
+lib and trainer, backends swap freely, and RL can hit a self-hosted index for
+reproducibility. `services/` (runtime services) is intentionally distinct from
+`infra/` (deployment/infrastructure).
+
+### 4.5 RL engine = slime, consumed as a Docker image (never vendored)
+slime wires Megatron (training) ↔ SGLang (rollout) through a Ray Data Buffer. It
+is consumed as `slimerl/slime:latest` (pin a digest for repro), not forked. Our
+entire contribution is two functions wired in by CLI flag, mirroring slime's own
+`examples/search-r1/`:
+
+| Our file | slime flag | Role |
 |---|---|---|
-| **Tinker API** | Managed LoRA training + GRPO + sampling. Handles compute, no local GPU needed for training. | Phase 1 |
-| **prime-rl** | Self-hosted async RL framework (FSDP2 + vLLM). Orchestrator → Trainer → Inference architecture. | Phase 2 |
-| **autoresearch** | Design pattern: autonomous agent experiment loop with git-based tracking. | Both phases |
-
----
-
-## 3. Phase 1: Tinker API + Evaluation + Autoresearch
-
-### 3.1 How Tinker Works
-
-Tinker is a remote training API from Thinking Machines (Mira Murati's lab). You write Python that calls their API — they handle the distributed GPU infrastructure. Key concepts:
-
-```python
-import tinker
-
-svc = tinker.ServiceClient()  # Authenticates via TINKER_API_KEY
-
-# Create a LoRA training client on a remote GPU
-tc = svc.create_lora_training_client(base_model="Qwen/Qwen3-8B", rank=32)
-
-# GRPO: generate completions, compute rewards, train
-sc = tc.save_weights_and_get_sampling_client()
-response = sc.sample(prompt=model_input, num_samples=group_size,
-                     sampling_params=SamplingParams(max_tokens=256))
-
-# Compute rewards locally, then send training data back
-tc.forward_backward(data=training_data, loss_fn="importance_sampling")
-tc.optim_step(adam_params=AdamParams(learning_rate=4e-5))
-```
-
-**What Tinker gives us for free:**
-- LoRA fine-tuning on any supported open-source model (Llama, Qwen, etc.)
-- GRPO training with `importance_sampling` loss (also PPO, CISPO, DRO)
-- Async training — overlap rollouts with GPU training for throughput
-- Sampling/generation from the current policy
-- Checkpoint save/load/download
-- No local GPU needed for training
-
-**What we still need to build:**
-- Evaluation environments and reward functions
-- The autoresearch experiment loop
-- Custom `ProblemEnv` / `MessageEnv` implementations for our tasks
-- Data pipeline (prompt datasets, eval sets)
-
-### 3.2 Tinker's Environment System
-
-Tinker provides a clean abstraction for RL environments:
-
-**`ProblemEnv` — single-turn answer verification (math, QA):**
-```python
-from tinker_cookbook.rl.problem_env import ProblemEnv, ProblemGroupBuilder
-
-class MathEnv(ProblemEnv):
-    def get_question(self) -> str: ...
-    def check_answer(self, sample_str: str) -> bool: ...
-    def check_format(self, sample_str: str) -> bool: ...
-    def get_reference_answer(self) -> str: ...
-```
-Reward formula: `format_coef * (check_format - 1) + check_answer`
-
-**`MessageEnv` — multi-turn conversations (tool use, games):**
-```python
-from tinker_cookbook.rl.message_env import MessageEnv, MessageStepResult
-
-class ToolUseEnv(MessageEnv):
-    async def initial_observation(self) -> list[Message]: ...
-    async def step(self, message: Message) -> MessageStepResult: ...
-```
-
-**Built-in environments we can use immediately:**
-- `Gsm8kDatasetBuilder` — grade-school math
-- `ArithmeticDatasetBuilder` — simple arithmetic
-- `DeepcoderDatasetBuilder` — code generation with sandbox
-
-### 3.3 Evaluation Framework
-
-Build `eval/` with pluggable evaluation environments. These are independent of the training backend — they work with Tinker now and prime-rl later.
-
-| Environment | Type | Metric | Description |
-|---|---|---|---|
-| **Math reasoning** (GSM8K, MATH) | ProblemEnv | Accuracy | Parse final answer, compare to ground truth |
-| **Code generation** (HumanEval, MBPP) | ProblemEnv | pass@k | Execute generated code against test cases |
-| **Tool use** (calculator, search) | MessageEnv | Task completion rate | Multi-turn: agent calls tools, gets results |
-| **Instruction following** (IFEval) | ProblemEnv | Constraint satisfaction | Does output follow formatting/content rules? |
-
-**Primary metric for autoresearch:** Single scalar `eval_score` — start with GSM8K accuracy alone, later move to a weighted composite.
-
-### 3.4 Autoresearch Adaptation for Tinker
-
-The autoresearch pattern adapts naturally to Tinker. The key difference: instead of modifying a local `train.py` that runs on a GPU, the agent modifies a script that makes Tinker API calls.
-
-**Three-file architecture:**
-```
-prepare.py          # Fixed: data prep, eval harness, Tinker client setup
-                    # Downloads datasets, defines compute_score()
-                    # NOT modified by the agent
-
-rl/train.py         # Agent-editable: Tinker training recipe
-                    # Everything is fair game: model choice, GRPO hyperparams,
-                    # group_size, learning rate, reward shaping, max_tokens, etc.
-                    # Calls Tinker API for training + sampling
-
-program.md          # Human-editable: agent instructions
-```
-
-**The experiment loop:**
-```
-SETUP:
-1. Create Tinker training client with base model + LoRA
-2. Run eval to establish baseline score
-3. Initialize results.tsv
-
-LOOP:
-1. Agent reads current state: git branch, results.tsv, recent experiments
-2. Agent modifies rl/train.py with an experimental idea
-   (e.g., "try group_size=16 instead of 8", "switch to Qwen3-8B",
-    "add format reward for chain-of-thought", "increase max_tokens to 512")
-3. git commit
-4. Run: python rl/train.py > run.log 2>&1
-5. Read results: grep "^eval_score:" run.log
-6. If eval_score improved → keep (advance branch)
-7. If eval_score same or worse → git reset
-8. Log to results.tsv
-9. GOTO 1
-```
-
-**Experiment budget:** Tinker API calls have latency but no fixed GPU time budget. We enforce a wall-clock budget (e.g., 10-15 min per experiment) that covers N training steps + eval. This is tunable in `prepare.py`.
-
-### 3.5 What the Agent Can Experiment With
-
-| Category | Examples |
-|---|---|
-| Model selection | `Llama-3.2-1B`, `Qwen3-8B`, `Qwen3-30B-A3B` (MoE, cost-efficient) |
-| LoRA config | rank (16, 32, 64), target modules (attn, mlp, unembed) |
-| GRPO hyperparams | group_size (4, 8, 16), learning_rate (1e-5 to 4e-5), kl_penalty_coef |
-| Loss function | `importance_sampling`, `ppo`, `cispo`, `dro` |
-| Generation | temperature, max_tokens, top_p |
-| Reward design | Format reward coefficient, reward composition |
-| Training dynamics | Steps per experiment, batch size, LR schedule |
-| Async config | `max_steps_off_policy`, `groups_per_batch` |
-
----
-
-## 4. Phase 2: Migration to prime-rl (Future)
-
-### 4.1 Why prime-rl
-
-Once the evaluation and autoresearch infrastructure is proven with Tinker, we migrate to prime-rl for:
-
-- **Full control over the training loop** — modify optimizers, loss functions, model architectures directly.
-- **Scale to 1000+ GPUs** with FSDP2 + vLLM async architecture.
-- **Self-hosted** — no API costs, no dependency on external service availability.
-- **Agentic multi-turn training** — prime-rl is designed for async agentic RL with `verifiers` environments.
-- **Custom algorithms** — bring your own loss functions, not limited to Tinker's supported set.
-
-### 4.2 prime-rl Architecture (for reference)
-
-prime-rl has three components that run as separate processes:
-
-```
-┌─────────────┐    rollouts    ┌──────────────┐   packed batches   ┌─────────────┐
-│  Inference   │ ──────────→   │ Orchestrator  │ ──────────────→    │   Trainer   │
-│  (vLLM)     │ ←──────────   │  (CPU, async) │ ←──────────────    │  (FSDP2)   │
-│             │   new weights  │              │   updated weights   │            │
-└─────────────┘               └──────────────┘                     └─────────────┘
-```
-
-- **Orchestrator:** Collects rollouts, computes advantages, dispatches batches, relays weights.
-- **Trainer:** FSDP2-distributed training, receives packed batches, updates model.
-- **Inference:** vLLM-based generation server, serves current (or slightly stale) policy.
-
-**Key prime-rl features we'll use:**
-- LoRA support (including multi-LoRA for parallel experiments)
-- `verifiers` environment integration
-- TOML config system
-- Async off-policy training (up to k steps of staleness)
-- Built-in examples: reverse text, wordle, alphabet sort, wiki search, math
-
-### 4.3 Migration Path
-
-The migration is clean because we're separating concerns:
-
-| Component | Phase 1 (Tinker) | Phase 2 (prime-rl) |
-|---|---|---|
-| Training backend | Tinker API calls | prime-rl trainer + orchestrator + inference |
-| RL algorithm | Tinker's `importance_sampling` / `ppo` | prime-rl's loss functions (IPO, custom) |
-| Generation | Tinker `SamplingClient` | prime-rl vLLM inference server |
-| **Eval environments** | **Our code (portable)** | **Same code, unchanged** |
-| **Reward functions** | **Our code (portable)** | **Same code, unchanged** |
-| **Autoresearch loop** | **Our code (portable)** | **Same code, minor edits to train.py** |
-| Config | Python kwargs to Tinker | TOML files for prime-rl |
-
-The eval/, reward, and autoresearch infrastructure transfers directly. Only `rl/train.py` changes — from Tinker API calls to prime-rl config + launch commands.
-
-### 4.4 prime-rl Environment Compatibility
-
-prime-rl uses `verifiers` environments from the [Environments Hub](https://app.primeintellect.ai/dashboard/environments). Our Tinker `ProblemEnv` / `MessageEnv` implementations can be adapted to `verifiers` format. Plan:
-
-1. Build eval environments using Tinker's `ProblemEnv` interface first (simpler, faster iteration).
-2. When migrating, wrap them as `verifiers` environments for prime-rl compatibility.
-3. Alternatively, build directly on `verifiers` if we want to skip the Tinker-specific layer.
-
----
-
-## 5. Proposed Directory Structure
-
-```
-lora-instruct/
-├── prepare.py                  # NEW: fixed data prep + eval harness
-├── program.md                  # NEW: autoresearch agent instructions
-├── results.tsv                 # NEW: experiment log (untracked by git)
-│
-├── rl/
-│   ├── train.py                # THE agent-editable file for autoresearch
-│   │                           # Phase 1: Tinker API calls
-│   │                           # Phase 2: prime-rl config + launch
-│   ├── envs/
-│   │   ├── math_env.py         # GSM8K / MATH environment (ProblemEnv)
-│   │   ├── code_env.py         # Code generation environment
-│   │   ├── tool_env.py         # Tool use environment (MessageEnv)
-│   │   └── instruction_env.py  # Instruction following environment
-│   └── rewards.py              # Reward function interfaces + composites
-│
-├── eval/
-│   ├── harness.py              # Unified evaluation runner
-│   ├── datasets.py             # Eval dataset loading (GSM8K, HumanEval, etc.)
-│   └── metrics.py              # Metric computation + composite scoring
-│
-├── sft/
-│   ├── train.py                # Refactored from finetune.py (kept for reference)
-│   └── configs/                # SFT config presets
-│
-├── utils/
-│   ├── prompter.py             # Extended prompt templates (existing)
-│   ├── callbacks.py            # Streaming helpers (existing)
-│   └── tinker_utils.py         # NEW: Tinker API helpers and wrappers
-│
-├── templates/
-│   ├── alpaca.json             # Existing
-│   ├── chatml.json             # NEW: ChatML format
-│   └── reasoning.json          # NEW: with <think> tags for reasoning
-│
-├── finetune.py                 # Existing (kept, still works)
-├── inference/                  # Existing benchmarking (keep as-is)
-├── dataset/                    # Existing SFT datasets
-├── notebook/                   # Existing notebooks
-├── docs/
-│   ├── architecture.md         # Updated
-│   ├── development.md          # Updated
-│   └── plan-deep-agent-rl.md   # This document
-│
-├── pyproject.toml              # Updated dependencies
-└── Research/                   # Autoresearch experiment branches and analysis
-```
-
----
-
-## 6. Dependencies
-
-### Phase 1 (Tinker)
-
-```toml
-# Tinker SDK + cookbook
-tinker = ">=0.1.0"
-tinker-cookbook = {git = "https://github.com/thinking-machines-lab/tinker-cookbook.git"}
-
-# Evaluation
-datasets = ">=3.0.0"           # HuggingFace datasets (GSM8K, etc.)
-
-# Existing (keep)
-transformers = ">=4.45.0"
-peft = ">=0.14.0"
-accelerate = ">=1.0.0"
-```
-
-### Phase 2 (prime-rl, future)
-
-```toml
-# prime-rl framework
-prime-rl = {git = "https://github.com/PrimeIntellect-ai/prime-rl.git"}
-# Requires: torch, vllm, flash-attn, verifiers
-```
-
----
-
-## 7. Implementation Roadmap
-
-### Milestone 1: Tinker + GSM8K Baseline (Week 1-2)
-
-**Goal:** GRPO training on GSM8K via Tinker, with eval and autoresearch scaffolding.
-
-1. Set up Tinker API key and verify connectivity.
-2. Build `rl/envs/math_env.py` — GSM8K `ProblemEnv` using Tinker's interface.
-3. Build `eval/harness.py` — evaluate a model on GSM8K via Tinker `SamplingClient`.
-4. Build `rl/train.py` — minimal GRPO training script using Tinker's `train.main()` or manual loop.
-5. Run baseline: establish GSM8K accuracy for an untrained model, then after N GRPO steps.
-
-### Milestone 2: Autoresearch Loop (Week 3-4)
-
-**Goal:** Autonomous agent can run experiments overnight on Tinker.
-
-6. Write `prepare.py` — downloads GSM8K data, defines `compute_score()`.
-7. Write `program.md` — full agent instructions for Tinker-based RL experiments.
-8. Ensure `rl/train.py` emits `eval_score:` line and respects time budget.
-9. Set up git branching workflow (`autoresearch/<tag>`).
-10. Test: run 5-10 autonomous experiments, verify keep/discard logic.
-
-### Milestone 3: Expanded Environments (Week 5-6)
-
-**Goal:** Multiple eval environments, composite scoring.
-
-11. Build `rl/envs/tool_env.py` — multi-turn calculator/search tool use (`MessageEnv`).
-12. Build `rl/envs/code_env.py` — code generation with Tinker's `DeepcoderDatasetBuilder` or custom.
-13. Implement composite scoring in `eval/metrics.py`.
-14. Update `program.md` with guidance for multi-environment optimization.
-15. Stress-test: overnight autoresearch run (target: 30+ experiments).
-
-### Milestone 4: prime-rl Migration (Future)
-
-**Goal:** Self-hosted RL training with full control.
-
-16. Set up prime-rl on GPU cluster (or single GPU for dev).
-17. Port `ProblemEnv`/`MessageEnv` implementations to `verifiers` environments.
-18. Rewrite `rl/train.py` to launch prime-rl components (orchestrator + trainer + inference).
-19. Write TOML configs for our training setups.
-20. Verify: same eval improvements as Tinker, but self-hosted.
-21. Scale: multi-GPU async training, larger models, longer experiments.
-
----
-
-## 8. Key Design Decisions
-
-### 8.1 Tinker First, prime-rl Later
-
-**Rationale:** Tinker lets us skip the hardest part (building a distributed RL training loop) and focus on what matters most: evaluation environments, reward design, and the autoresearch loop. Once those are validated, swapping the training backend is a targeted change to one file (`rl/train.py`).
-
-**Trade-off:** We depend on Tinker's API for Phase 1 (cost, availability, supported models). But Phase 1 is about proving the concept, not production scale.
-
-### 8.2 GRPO as Default Algorithm
-
-**Rationale:** Both Tinker and prime-rl support GRPO natively. It eliminates the critic model (memory-efficient), works well with verifiable rewards (math, code), and is the standard since DeepSeek-R1. Tinker uses `importance_sampling` loss for GRPO; prime-rl uses its IPO variant.
-
-### 8.3 LoRA Throughout
-
-**Rationale:** Tinker only does LoRA fine-tuning (by design — they believe LoRA matches full fine-tuning for RL). prime-rl also supports LoRA natively. This is our project's core identity and makes everything faster and cheaper.
-
-### 8.4 Evaluation as the Stable Core
-
-**Rationale:** The eval framework (`eval/`, `rl/envs/`, `rl/rewards.py`) is the one piece that doesn't change between Tinker and prime-rl. Building it well in Phase 1 means Phase 2 migration is just a training backend swap. This is also what autoresearch optimizes against — it's the ground truth.
-
-### 8.5 MoE Models for Cost Efficiency
-
-**Rationale:** Tinker bills by active parameters. MoE models like `Qwen3-30B-A3B` (3B active out of 30B total) give near-large-model quality at small-model cost. Prefer these for Phase 1 experiments.
-
----
-
-## 9. Risks and Mitigations
-
-| Risk | Impact | Mitigation |
-|---|---|---|
-| Tinker API costs add up during autoresearch | Budget overrun from 50+ experiments | Start with small models (1-3B active); set per-experiment step limits; monitor costs |
-| Tinker API availability/rate limits | Experiments stall overnight | Add retry logic; autoresearch handles failures gracefully (log crash, move on) |
-| Evaluation too slow via Tinker sampling | Time budget blown on eval, not training | Use small eval subsets (200 problems); cache baseline completions |
-| Tinker → prime-rl migration harder than expected | Environments don't port cleanly | Design environments against a thin interface; abstract Tinker-specific bits |
-| Reward hacking | Agent games the metric | Use verifiable rewards; composite scoring; human review of autoresearch logs |
-
----
-
-## 10. Success Criteria
-
-### Phase 1 (Tinker)
-
-1. **GRPO training runs end-to-end** on GSM8K via Tinker API.
-2. **RL improves over baseline** on GSM8K (target: +5% accuracy after N steps).
-3. **Autoresearch runs 30+ experiments** overnight without human intervention.
-4. **At least 15% of experiments are "keep"** (meaningful improvement rate).
-5. **At least 2 eval environments** working (math + one of: code, tool use, instruction).
-
-### Phase 2 (prime-rl, future)
-
-6. **Same eval improvements** reproduced on self-hosted prime-rl.
-7. **Scale to 4+ GPUs** with async training.
-8. **Autoresearch runs 50+ experiments** overnight.
-9. **Multi-turn agent training** working (tool use or similar).
-
----
-
-## 11. References
-
-### Core Systems
-
-- [Tinker API](https://tinker-docs.thinkingmachines.ai/) — managed RL training API (Phase 1 backend)
-- [Tinker Cookbook](https://github.com/thinking-machines-lab/tinker-cookbook) — recipes, environments, and skills for Tinker
-- [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl) — async RL training at scale (Phase 2 backend)
-- [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — autonomous experiment loop pattern
-
-### RL Algorithms & Research
-
-- [DeepSeek-R1](https://arxiv.org/abs/2401.12954) — GRPO for reasoning model training
-- [Tree-GRPO (ICLR 2026)](https://github.com/AMAP-ML/Tree-GRPO) — tree-search rollout strategy for agent RL
-- [OpenRLHF](https://github.com/OpenRLHF/OpenRLHF) — reference for scalable RL architecture
-- [TRL GRPOTrainer](https://huggingface.co/docs/trl/main/en/grpo_trainer) — HuggingFace RL library
-- [ART (Agent Reinforcement Trainer)](https://github.com/OpenPipe/ART) — GRPO for multi-step agents
-
-### Evaluation
-
-- [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) — standardized LLM benchmarks
-- [verifiers](https://github.com/PrimeIntellect-ai/verifiers) — prime-rl's environment abstraction
+| `plugins/rollout.py::generate` | `--custom-generate-function-path` | runs the shared `dr_agent` loop; fills the slime `Sample` contract |
+| `plugins/reward.py::reward_func` | `--custom-rm-path` | shims slime's `Sample` to `dr_agent.rewards` |
+
+**The Sample contract is the whole integration surface.** `generate(args, sample,
+sampling_params)` must set `sample.tokens` (prompt+response ids),
+`sample.response`, `sample.response_length`, `sample.loss_mask` (0 for
+prompt/tool-observation tokens so only model-generated tokens get a gradient),
+and `sample.status`. `reward_func(args, sample, **kwargs) -> float` reads ground
+truth from `sample.label`.
+
+Install/launch: pull the image, run the container with this recipe bind-mounted
+and GPUs attached, `pip install -e libs/dr_agent --no-deps`, then `bash
+launch/run.sh` (or `ray job submit ... -- python3 train.py ...` for multi-node).
+HF→Megatron weight conversion is a pre-step. See
+`training/rl_deepresearch/engine/README.md`.
+
+### 4.6 Data-gen = `core/` + `domains/<name>/`
+Stage base-classes in `core/` (explore/verify/distract/extend); each domain
+subclasses them with an identical, stage-named file layout and a `__main__.py`
+orchestrator. Stages write to separate `raw/ → verified/ → final/` dirs (not
+mutate-in-place) for clean partial reruns. Generated tasks carry ground truth and
+match the `dr_agent` scoring schema, so the data doubles as train + eval.
+
+## 5. Status
+
+Scaffold landed; the reward registry is implemented and tested (5 tests pass).
+The following are `NotImplementedError` stubs awaiting implementation:
+
+- `dr_agent.agent.loop.run_agent` — the ReAct loop (highest leverage: training,
+  eval, and serving all block on it).
+- `search_server` endpoints + index builder backends.
+- `datagen` web stages (explore/verify/distract/extend).
+- `plugins/rollout.py` Sample-contract population (tokenization + `loss_mask`).
+- slime image-digest pin + HF→Megatron conversion wiring.
+- `rubric` / `citation` reward scorers.
+
+## 6. Suggested order of implementation
+
+1. `dr_agent.agent.loop.run_agent` (unblocks everything).
+2. `search_server` `/search` + `/visit` against one backend (bm25), so the loop
+   has real tools.
+3. `eval/` end-to-end on one benchmark (proves the generate→score path).
+4. `datagen` web pipeline (produces training/eval data).
+5. `plugins/rollout.py` Sample contract + a first slime GRPO run.
+
+## 7. References
+
+- [slime (THUDM)](https://github.com/THUDM/slime) — RL engine (Megatron + SGLang)
+- Surveyed repos: [DR-Tulu](https://github.com/rlresearch/DR-Tulu),
+  [QUEST](https://github.com/OSU-NLP-Group/QUEST),
+  [Search-R1](https://github.com/PeterGriffinJin/Search-R1),
+  [DeepResearcher](https://github.com/GAIR-NLP/DeepResearcher),
+  [StepDeepResearch](https://github.com/stepfun-ai/StepDeepResearch),
+  [context-1-data-gen](https://github.com/chroma-core/context-1-data-gen)
+- PRD (status tracker): [prd/deep-research-training-eval-infra.md](../prd/deep-research-training-eval-infra.md)

--- a/eval/.gitignore
+++ b/eval/.gitignore
@@ -1,0 +1,4 @@
+# eval run artifacts — never commit rollout dumps / reports
+results/
+*.jsonl
+!benchmarks/**/tasks.jsonl

--- a/prd/README.md
+++ b/prd/README.md
@@ -20,6 +20,7 @@ delete-on-ship convention, e.g. the removed `streaming.md`).
 | PRD | Status | Scope |
 |---|---|---|
 | [monorepo-reorg.md](monorepo-reorg.md) | `complete` | Waves 0–5 and 7 landed; optional Wave 6 is deferred until a third delulu app exists. |
+| [deep-research-training-eval-infra.md](deep-research-training-eval-infra.md) | `in-progress` | Training + eval infra for a deep-research agent: shared `libs/dr_agent`, `services/search_server`, `data/datagen`, `eval/`, slime RL recipe. Scaffold + reward registry landed; loops/backends are stubs. |
 | [codex-ci-auth.md](codex-ci-auth.md) | `v1-shipped · v2-parked` | Codex CLI auth in CI via ChatGPT `auth.json` (not `OPENAI_API_KEY`). Core landed; API-key fallback + multi-identity parked. |
 | [claude-action-install-flake.md](claude-action-install-flake.md) | `not-started` | Work around `claude-code-action` native installer reporting success while the binary is absent. |
 | [code-review-skip-approve.md](code-review-skip-approve.md) | `not-started` | Make the code-review bot **approve** on the doc-only skip path instead of leaving a non-approving comment. |

--- a/prd/deep-research-training-eval-infra.md
+++ b/prd/deep-research-training-eval-infra.md
@@ -1,0 +1,82 @@
+# Deep-research training + evaluation infrastructure
+
+**Status:** `in-progress` — scaffold landed (empty skeletons + working reward
+registry); rollout/agent loop, search backends, and data-gen stages are `NotImplementedError` stubs.
+
+## Why
+
+Turn SMILE-factory into training + evaluation infrastructure for a deep-research
+agent (RL post-training + benchmark eval), without breaking the category-first
+monorepo conventions. Design was driven by a survey of six deep-research
+codebases: DR-Tulu, QUEST, Search-R1, DeepResearcher, StepDeepResearch, and
+chroma context-1-data-gen.
+
+## Key decisions (and the evidence behind them)
+
+1. **One shared agent+tool+reward library in `libs/dr_agent`.** It is imported by
+   `training/`, `eval/`, and `apps/`, so the agent loop and scorers are identical
+   across train/eval/serve. The surveyed repos that skipped this (QUEST, Search-R1)
+   duplicated tool code 3–4× and drifted; the ones that built it (DR-Tulu
+   `dr-agent-lib`, StepFun `cortex`) are the ones worth copying. This is also the
+   only sanctioned cross-project import surface per the root CLAUDE.md.
+
+2. **Reward = a flat registry keyed by `data_source`**, living in the shared lib
+   (`dr_agent.rewards`). RL reward and eval scoring both call `score(row)`. Add a
+   task = add one scorer file. (Search-R1 `reward_score/`, DR-Tulu `search_rewards/`.)
+
+3. **`eval/` is a standalone top-level category, two-phase (generate → score).**
+   Search-R1 and DeepResearcher collapsed eval into "val batches + reward inside
+   the trainer," which makes eval irreproducible outside a training run. We keep
+   one folder per benchmark + shared `samplers/` (DR-Tulu / QUEST pattern).
+
+4. **Tools are an HTTP service in `services/` (`search_server`).** Heavy retrieval
+   deps (bm25/faiss) are isolated from the lib and trainer; backends swap behind a
+   stable `/search` `/retrieve` `/visit` contract; RL can hit a self-hosted index
+   for reproducibility. `services/` (runtime services) is distinct from `infra/`
+   (deployment). This is the most-copied pattern across all six repos.
+
+5. **RL engine = slime (THUDM/slime), consumed as a Docker image, never vendored.**
+   Every surveyed RL repo vendored its engine (verl/open-instruct) — flagged as the
+   #1 smell. slime's plugin model lets us avoid that entirely: our whole
+   contribution is two functions wired in by CLI flag, mirroring slime's
+   `examples/search-r1/`:
+   - `plugins/rollout.py::generate` → `--custom-generate-function-path` (drives the
+     shared `dr_agent` loop, fills the slime `Sample` contract incl. `loss_mask`).
+   - `plugins/reward.py::reward_func` → `--custom-rm-path` (shim to `dr_agent.rewards`).
+
+6. **`data/datagen` = `core/` base stages + `domains/<name>/` subclasses**, stages
+   as runnable modules with a `__main__.py` orchestrator, output written
+   `raw/ → verified/ → final/` (not mutate-in-place). Generated tasks carry ground
+   truth and conform to the `dr_agent` scoring schema, so data doubles as
+   train + eval. (chroma context-1-data-gen, improved.)
+
+## Layout delivered
+
+```
+libs/dr_agent/              shared agent loop + tools + reward registry + prompts
+services/search_server/     tool/search HTTP service (bm25/dense/web backends)
+data/datagen/               core/ + domains/<name>/ synthetic task generation
+eval/                       two-phase harness + benchmarks/<name>/ + samplers/
+training/rl_deepresearch/   slime recipe: plugins/ + configs/ + launch/ + engine(README)
+```
+
+All new projects use uv + hatchling + `src/` layout + ruff (matching the active
+delulu apps). Each owns its `pyproject.toml`, `Makefile`, and `CLAUDE.md`.
+
+## What is NOT done yet
+
+- `dr_agent.agent.loop.run_agent` — the ReAct loop (raises `NotImplementedError`).
+- `search_server` endpoints + index builder backends.
+- `datagen` web stages (explore/verify/distract/extend).
+- `plugins/rollout.py` Sample-contract population (tokenization + `loss_mask`).
+- slime image digest pin; HF→Megatron weight conversion step.
+- Only `exact_match` + `f1` scorers exist; `rubric`/`citation` are TODO.
+
+## Open questions / parked
+
+- **slime via bind-mount vs. baked Dockerfile** — dev uses bind-mount; a pinned
+  `engine/Dockerfile` (`FROM slimerl/slime@sha256:…`) may be wanted for CI/repro.
+- **SFT recipe** — `training/lora_instruct` (poetry) stays as-is; if a deep-research
+  SFT cold-start is needed, add a sibling recipe rather than extending it.
+- **PR strategy** — per "one PR per project," this scaffold should land as several
+  PRs (one per new project) plus a cross-cutting PR for root `Makefile`/`CLAUDE.md`.


### PR DESCRIPTION
Replaces the prior Tinker/prime-rl plan with the chosen slime-based deep-research architecture (docs/plan-deep-agent-rl.md), adds the PRD + index row, and wires root Makefile (`dr-check`) and CLAUDE.md for the new libs/services/data/eval/training projects. Cross-cutting PR per the one-PR-per-project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)