### PR TITLE
fix(eval): cap self-hosted maxTokens to resolve BenchFlow HTTP 500

### DIFF
--- a/eval/_tooling/Makefile
+++ b/eval/_tooling/Makefile
@@ -27,12 +27,25 @@ N ?= 50
 # ENGINE_PORT: local engine — SGLang 30000, vLLM 8000
 ENGINE_PORT ?= 30000
 ENGINE_URL ?= http://localhost:$(ENGINE_PORT)/v1
+# Token budget for the self-hosted model. CRITICAL: without an explicit maxTokens,
+# benchflow's pi-acp registers the model with maxTokens = its own _DEFAULT_MAX_TOKENS
+# (16384) and pi then asks SGLang for a completion that large — prompt+completion
+# overflows the 16384 context, so SGLang rejects EVERY call and litellm mislabels it
+# a transient HTTP 500 (errored=all). Cap the completion well under ENGINE_CONTEXT so
+# input+output fits. See docs/benchflow-engine-500.md.
+ENGINE_CONTEXT ?= 16384
+ENGINE_MAXTOK ?= 2048
+# bare model id (strip the vllm/ provider prefix) for pi's model-registry entry
+MODEL_ID := $(patsubst vllm/%,%,$(MODEL))
+# compact JSON (NO spaces — single-quoted in the recipe so bash doesn't brace-expand it)
+ENGINE_MODELS := [{"id":"$(MODEL_ID)","name":"$(MODEL_ID)","contextWindow":$(ENGINE_CONTEXT),"maxTokens":$(ENGINE_MAXTOK),"reasoning":false,"input":["text"]}]
 
 # Self-hosted models (BenchFlow's `vllm/` provider = any local OpenAI endpoint)
-# need the engine URL injected + a placeholder key, and a reachable engine.
-# First-party agents/models (claude/codex/…) bring their own auth, so skip both.
+# need the engine URL injected + a placeholder key + a model entry that caps
+# maxTokens (above), and a reachable engine. First-party agents/models
+# (claude/codex/…) bring their own auth + metadata, so skip all of it.
 ifneq ($(findstring vllm/,$(MODEL)),)
-  ENGINE_ENV := --agent-env BENCHFLOW_PROVIDER_BASE_URL=$(ENGINE_URL) --agent-env OPENAI_API_KEY=dummy-key
+  ENGINE_ENV := --agent-env BENCHFLOW_PROVIDER_BASE_URL=$(ENGINE_URL) --agent-env OPENAI_API_KEY=dummy-key --agent-env 'BENCHFLOW_PROVIDER_MODELS=$(ENGINE_MODELS)'
   ENGINE_DEP := check-engine
 else
   ENGINE_ENV :=

--- a/eval/_tooling/README.md
+++ b/eval/_tooling/README.md
@@ -43,6 +43,9 @@ the `make eval` driver, not from per-benchmark config.
 
 ```
 eval/
+  benchmarks/simpleqa/
+    simple_qa_test_set.csv        optional local dataset copy (gitignored); gen fetches from the upstream URL if absent
+    tasks/<id>/                   generated task dirs (gitignored): task.md + verifier/
   benchmarks/<name>/tasks/<id>/   generated task dirs (gitignored): task.md + verifier/
   _tooling/                       run everything from here
     Makefile                      the `make eval BENCHMARK/AGENT/MODEL` driver
@@ -98,10 +101,12 @@ make eval BENCHMARK=hotpotqa AGENT=claude MODEL=claude-haiku-4-5-20251001
 `make eval` is the runner; `AGENT`/`MODEL` are the only things you change to swap
 harness/model. Outputs land in `_runs/<agent>/<benchmark>/`.
 
-> **Heads-up:** the BenchFlow run currently 500s with the self-hosted SGLang engine
-> (see [`docs/benchflow-engine-500.md`](docs/benchflow-engine-500.md)). Until that's
-> fixed, `make eval-direct BENCHMARK=<b>` gives a Docker-free signal (pi → engine,
-> same tasks + scorer, **not** BenchFlow) → `_runs/_direct-debug/<benchmark>/report.json`.
+> **Heads-up:** `make eval` injects `BENCHFLOW_PROVIDER_MODELS` with a `maxTokens`
+> cap (`ENGINE_MAXTOK`, default 2048). Without it, benchflow's pi-acp asks SGLang for
+> a 16384-token completion that overflows the 16384 context and **every call 500s**
+> (resolved — see [`docs/benchflow-engine-500.md`](docs/benchflow-engine-500.md)).
+> For a quick Docker-free signal, `make eval-direct BENCHMARK=<b>` runs pi → engine
+> with the same tasks + scorer (**not** BenchFlow) → `_runs/_direct-debug/<benchmark>/report.json`.
 
 A BenchFlow job lands in `_runs/<agent>/<benchmark>/<timestamp>/` — per-task
 `reward.txt`/`result.json` + a job `summary.json`.
@@ -119,23 +124,20 @@ The run-configs point the host-side LiteLLM proxy at `http://localhost:30000/v1`
 (proxy → SGLang, both on the host). BenchFlow's `vllm/` prefix just means
 "self-hosted OpenAI API"; SGLang serves the same protocol.
 
-### ⚠️ Known issue: BenchFlow agentic run → HTTP 500 with a self-hosted engine
+### ✅ Resolved: BenchFlow agentic run → HTTP 500 with a self-hosted engine
 
-The **full agentic BenchFlow run currently fails** — every model call comes back
-to the agent as `provider api error … HTTP 500` (the engine itself returns 200).
-Every layer reproduces 200 in isolation on the host (engine, `litellm` lib, the
-route, BenchFlow's callback, its exact proxy config, pi's exact request); the 500
-only appears in the live run where the proxy is bound to `host.docker.internal`
-and pi streams from inside the sandbox — pointing at the container↔host streaming
-path under Docker-Desktop-WSL. (Note: BenchFlow's `vllm/` provider routes via
-litellm `openai/` + api_base, **not** `hosted_vllm/`.)
+Earlier, the full agentic run failed — every model call came back as `provider api
+error … HTTP 500` (the engine itself returned 200). **Root cause:** benchflow's
+pi-acp defaulted the model's `maxTokens` to `16384` (its `_DEFAULT_MAX_TOKENS`),
+so pi requested a completion as large as the *entire* 16384 context; `prompt +
+16384 > 16384`, so SGLang rejected every call with a context-length error that
+litellm mislabeled as a transient HTTP 500. **Fix:** `make eval` injects
+`BENCHFLOW_PROVIDER_MODELS` with `maxTokens=ENGINE_MAXTOK` (2048) so the completion
+fits. (Note: BenchFlow's `vllm/` provider routes via litellm `openai/` + api_base,
+**not** `hosted_vllm/`.)
 
-Full investigation, isolation matrix, repro recipe, and fix directions:
+Full investigation, proof, and the upstream-worthy notes:
 **[`docs/benchflow-engine-500.md`](docs/benchflow-engine-500.md)**.
-
-This blocks `make eval` (the BenchFlow runner) with the self-hosted engine. Until
-it's fixed, use `make eval-direct` for a Docker-free signal (below), or a
-first-party agent/model that doesn't go through the self-hosted path.
 
 ### Docker-Desktop-on-WSL networking patch
 

--- a/eval/_tooling/docs/benchflow-engine-500.md
+++ b/eval/_tooling/docs/benchflow-engine-500.md
@@ -1,146 +1,105 @@
 # BenchFlow agentic run → `provider api error / HTTP 500` with a self-hosted engine
 
-**Status:** open, root-cause narrowed (not fully pinned). **Workaround:**
-`make eval-direct` (a Docker-free debug fallback) while this is open.
+**Status:** ✅ **RESOLVED.** Root cause found and fixed in the `make eval` driver
+(`_tooling/Makefile`). Kept here as the investigation record because the symptom
+(a "transient HTTP 500" on a self-hosted engine) is misleading and worth knowing.
 
 ## TL;DR
 
-Running the full agentic BenchFlow path against a **self-hosted** engine (SGLang,
-or vLLM-with-tool-calls) fails: **every** model call comes back to the agent as
-`provider api error [provider_error/transient] HTTP 500`, the task errors, reward
-is `0`. The **engine returns 200** on every request — the 500 is manufactured by
-BenchFlow's host-side **LiteLLM proxy** relaying to the agent.
+The full agentic BenchFlow path against a **self-hosted** engine (SGLang/vLLM)
+failed: **every** model call came back to the agent as `provider api error
+[provider_error/transient] HTTP 500`, every task errored, reward `0`.
 
-Crucially, the failure is **not** in any single component: the engine, the
-`litellm` library, the proxy *route*, BenchFlow's logging *callback*, BenchFlow's
-*exact proxy config*, and *pi's exact request* all return **200 in isolation on
-the host**. The 500 only appears in the live run, where the proxy is bound to
-`host.docker.internal` and the agent streams from **inside the Docker sandbox** —
-so the remaining suspect is the **container↔host streaming path under Docker
-Desktop on WSL**, the same networking class as the proxy-bind patch (see
-`README.md` → "Docker-Desktop-on-WSL networking patch").
+It is **not** a network/proxy/streaming bug. The real cause:
 
-## First, correct a misconception: there is no `hosted_vllm` route
+> **benchflow's pi-acp registers the model with `maxTokens = 16384` by default**
+> (`agents/pi_acp_launcher.py::_DEFAULT_MAX_TOKENS`) whenever `BENCHFLOW_PROVIDER_MODELS`
+> carries no explicit `maxTokens`. pi then asks for a **completion of 16384 tokens** —
+> the model's *entire* context. With any prompt, `prompt + 16384 > 16384`, so SGLang
+> rejects **every** call with a context-length error. litellm **mislabels** that
+> deterministic rejection as a *transient* `APIConnectionError` → the proxy returns
+> HTTP 500 → pi retries 12× → litellm Router cools the (single) deployment down →
+> all tasks fast-fail. The "transient 500" is a context-overflow 400 in disguise.
 
-The run-config says `model: vllm/qwen35-2b-base`. It's tempting to think BenchFlow
-routes that through litellm's `hosted_vllm/` provider. **It does not.** BenchFlow's
-`vllm/` provider is its generic "self-hosted OpenAI-compatible server" prefix, and
-it resolves to litellm **`openai/<model>` + a custom `api_base`**:
+**The proof** — the proxy's own `stderr.log`, captured live before benchflow deletes it:
 
-```text
-# benchflow.providers.litellm_config.resolve_litellm_route("vllm/qwen35-2b-base", …)
-model_alias:    benchflow-vllm-qwen35-2b-base
-litellm_params: {model: openai/qwen35-2b-base,
-                 api_base: http://localhost:30000/v1,
-                 api_key: os.environ/OPENAI_API_KEY}
+```
+APIConnectionError: OpenAIException - Requested token count exceeds the model's
+maximum context length of 16384 tokens. You requested a total of 17964 tokens:
+1580 tokens from the input messages and 16384 tokens for the completion.
 ```
 
-The proxy registers four aliases (`benchflow-vllm-…`, `openai/benchflow-vllm-…`,
-`qwen35-2b-base`, `openai/qwen35-2b-base`), all → `openai/qwen35-2b-base` @ api_base.
-pi is configured to call it as `litellm/benchflow-vllm-qwen35-2b-base`, where
-`litellm/` is **pi's provider name** (stripped before the wire); the wire model is
-`benchflow-vllm-qwen35-2b-base`.
+## The fix
 
-## Symptom signature
+Inject a model entry with a sane `maxTokens` so pi caps its completion request well
+under the context window. The `make eval` driver now does this for every `vllm/`
+(self-hosted) model:
 
-- Agent side: `[ERR] <task> (provider api error [provider_error/transient])`,
-  `api_error_info.status_counts = {"500": N}` for all N calls, `reward 0`.
-- `…/trajectory/llm_trajectory.jsonl`: each entry `response.status_code = 500`,
-  `response.body = {"raw": None, "error": {"type": "NoneType", "message": "None"}}`
-  — i.e. the proxy's failure callback recorded an empty response.
-- Engine (SGLang) access log: `POST /v1/chat/completions … 200 OK` for the
-  requests it received (from `127.0.0.1`, the host-side proxy).
-- vLLM "worked" earlier **only because that model never emitted tool calls** — the
-  agentic tool path (and its streaming responses) was never exercised.
+```make
+ENGINE_CONTEXT ?= 16384
+ENGINE_MAXTOK  ?= 2048
+ENGINE_MODELS  := [{"id":"$(MODEL_ID)","name":"$(MODEL_ID)","contextWindow":$(ENGINE_CONTEXT),"maxTokens":$(ENGINE_MAXTOK),"reasoning":false,"input":["text"]}]
+# --agent-env 'BENCHFLOW_PROVIDER_MODELS=$(ENGINE_MODELS)'
+```
 
-## Isolation matrix (all run on the host)
+benchflow's `_provider_models_for_proxy_alias` clones that entry onto the LiteLLM
+alias pi sees in proxy mode, so the cap survives routing. With `maxTokens=2048`:
+`1580 + 2048 = 3628 < 16384` → SGLang returns 200, pi tool-calls, the verifier scores.
 
-| # | Setup | tools | stream | Result |
-|---|-------|:----:|:-----:|--------|
-| 1 | SGLang direct (`curl :30000`) | ✓ | ✓ | **200**, valid tool_calls (`qwen3_coder` parser) |
-| 2 | `litellm` **library**, `openai/…`+api_base | ✓ | ✓ | **200** |
-| 3 | `litellm` **library**, `hosted_vllm/…`+api_base | ✓ | ✓ | **200** |
-| 4 | plain `litellm` **proxy**, `openai/…` route | ✓ | ✓ | **200** |
-| 5 | plain `litellm` **proxy**, `hosted_vllm/…` route | ✓ | ✓ | **200** |
-| 6 | proxy + BenchFlow's **callback** registered | ✓ | ✓ | **200** |
-| 7 | proxy with BenchFlow's **exact generated config** (4 aliases + callback + master_key + drop_params), wire model `benchflow-vllm-qwen35-2b-base` | ✓ | ✓ | **200** |
-| 8 | #7 + **pi's exact recorded request** (system+user msgs, 4 tools, stream) | ✓ | ✓ | **200** |
-| 9 | **BenchFlow live run** (proxy bound `host.docker.internal`, pi inside Docker sandbox) | ✓ | ✓ | **500** ✗ |
+**Verified:** a 2-task `make eval` run went from `errored=2` (all HTTP 500) to
+`errored=0, n_tool_calls=1, reward=0.0` (real answers, model just gets them wrong —
+that's the 2B *base* model's capability, not a plumbing fault).
 
-Everything up to and including pi's exact request, replayed against BenchFlow's
-exact proxy config, returns 200. The single thing #9 has that #8 doesn't: the
-**proxy is bound to `host.docker.internal` and the client (pi) is inside the
-container**, streaming back across the Docker-Desktop-WSL boundary.
+> Note: raising `ENGINE_CONTEXT` does **not** help on its own — pi would just request
+> the larger number as its completion and overflow again. The cap on `maxTokens` is
+> the fix. Keep `ENGINE_MAXTOK` comfortably below `ENGINE_CONTEXT − max_prompt_tokens`.
 
-(One red herring: sending the literal wire model `litellm/benchflow-vllm-qwen35-2b-base`
-to the proxy yields a clean **400 "Invalid model name"** — but pi strips its
-`litellm/` provider prefix before the wire, so this isn't what happens in the run.)
+## Why the earlier investigation pointed the wrong way
 
-## Most likely root cause
+Every isolation test (SGLang direct, litellm lib, the proxy with benchflow's exact
+config + callback, even from *inside a container* over `host.docker.internal`)
+returned **200** — so suspicion fell on the container↔host streaming path under
+Docker-Desktop-WSL. That was a **red herring**: those replays used pi's *logged*
+request body, where `max_tokens` was `None` (so SGLang applied a small default). The
+**live** pi-acp instead sends `max_tokens: 16384` from its model-registry default,
+which the logged trajectory didn't surface. The container topology works fine; the
+request itself was over-budget.
 
-A streaming chat-completion relayed **proxy(host) → pi(container) over
-`host.docker.internal`** drops / resets mid-stream under Docker Desktop on WSL2
-(engine in a separate VM). The proxy sees the client go away mid-stream, aborts
-the upstream call, and surfaces it to the agent as a transient provider 500 with
-an empty body — which matches the `raw: None` trajectory record. This is the same
-class of issue as the proxy *bind-address* problem already patched; reachability
-was fixed, but **streaming** across that boundary appears not to survive.
+The misclassification compounds it: SGLang's context-length error *should* be a
+non-retryable `BadRequestError`, but litellm tags it `APIConnectionError /
+provider_error/transient`, so benchflow retries 12× and cools the deployment down —
+making one bad request look like a flaky network.
 
-Not yet done: capture the proxy's own `stderr.log` from a live run (BenchFlow
-writes it to an ephemeral `/tmp/benchflow-litellm-*/` and **deletes it on
-teardown** — instrument `benchflow/providers/litellm_runtime.py` to keep it, or
-`tail -F` it during a run) to see the exact proxy-side exception at the moment of
-the 500. That is the one piece that would turn "most likely" into "confirmed."
+## How to confirm on a fresh run
 
-## Reproduction recipe
+benchflow writes the proxy's logs to an ephemeral `/tmp/benchflow-litellm-*/` and
+**deletes them on teardown**. To read them, grab them *while a run is in progress*:
 
 ```bash
-PYBF=~/.local/share/uv/tools/benchflow/bin/python
-# (a) the engine itself is fine:
-curl -s :30000/v1/chat/completions -d '{"model":"qwen35-2b-base","stream":true,
-  "messages":[{"role":"user","content":"hi"}],
-  "tools":[{"type":"function","function":{"name":"write","parameters":{}}}],
-  "tool_choice":"auto"}' -H 'content-type: application/json' | tail -1   # data: [DONE]
-
-# (b) BenchFlow's EXACT proxy config also serves 200 on the host:
-$PYBF - <<'PY'
-import yaml
-from benchflow.providers.litellm_config import resolve_litellm_route, litellm_proxy_config
-r = resolve_litellm_route("vllm/qwen35-2b-base",
-      {"BENCHFLOW_PROVIDER_BASE_URL":"http://127.0.0.1:30000/v1","OPENAI_API_KEY":"dummy"})
-yaml.safe_dump(litellm_proxy_config(r, master_key="sk-1234"), open("/tmp/bf.yaml","w"))
-PY
-$PYBF -c "from benchflow.providers.litellm_logging import callback_module_source as s;open('/tmp/benchflow_litellm_callback.py','w').write(s())"
-PYTHONPATH=/tmp OPENAI_API_KEY=dummy BENCHFLOW_LITELLM_LOG_PATH=/tmp/cb.jsonl \
-  ~/.local/share/uv/tools/benchflow/bin/litellm --config /tmp/bf.yaml --port 41890 &
-# POST with wire model "benchflow-vllm-qwen35-2b-base" + stream + tools  ->  200
-
-# (c) only the live run fails:  cd eval/_tooling && make eval BENCHMARK=simpleqa
+# during a live `make eval`:
+tail -n +1 /tmp/benchflow-litellm-*/stderr.log | grep -i "context length\|token count"
 ```
 
-## Fix directions (in rough order of payoff)
+A context-overflow line there = this bug. (No line + a real network error = a
+different problem.)
 
-1. **Bypass the proxy** — have pi talk directly to the engine inside the sandbox
-   (`host.docker.internal:30000`) instead of the host proxy. Costs BenchFlow's
-   proxy-side usage/cost/trajectory capture, but removes the cross-boundary stream.
-   (No clean BenchFlow flag for this today — proxy is "always used for routable
-   agents"; would need a small BenchFlow change.)
-2. **Confirm the streaming theory** — keep the proxy `stderr.log` (above) and read
-   the real exception; if it's a mid-stream client reset, try forcing non-streaming
-   in the proxy/agent path.
-3. **Use vLLM for the agentic path** — the proxy works with it (`make serve-vllm`,
-   set the run-config base URL to `:8000`); note the *base* model still rarely
-   tool-calls there, so scores stay low.
-4. **Report upstream** to benchflow-ai with this isolation matrix.
+## Symptom signature (for future triage)
 
-## Impact
+- Agent side: `api_error_info.status_counts = {"500": N}` for all N calls, `reward 0`,
+  `error_category: api_error`.
+- `…/trajectory/llm_trajectory.jsonl`: each `response.status_code = 500`,
+  `response.body = {"raw": None, "error": {"type": "NoneType", "message": "None"}}`
+  (benchflow's failure callback fired with `response_obj=None`).
+- Timing tell: first request ~400ms (a real attempt), the rest ~30ms (litellm Router
+  **cooldown** fast-fails) — a uniform, *instant* 500 storm, not random flakiness.
+- Engine returns 200 to a hand-replayed request → the difference is the **request**
+  (its `max_tokens`), not the route or the network.
 
-BenchFlow is the sole runner (`make eval`), so this bug currently blocks real runs
-against the **self-hosted** engine. Two ways forward until it's fixed:
-- `make eval-direct` — Docker-free debug signal (pi → engine, same tasks + scorer,
-  **not** BenchFlow). Good for sanity-checking the model, not a substitute.
-- A first-party agent/model (`make eval AGENT=claude MODEL=…`) doesn't go through
-  the self-hosted proxy path, so it's unaffected.
+## Upstream-worthy notes (benchflow-ai)
 
-Fixing **Fix direction #1** (pi → engine direct inside the sandbox) is the clean
-unblock for self-hosted models under BenchFlow.
+1. `pi_acp_launcher._DEFAULT_MAX_TOKENS = 16384` is a poor default for a 16k-context
+   model: it equals the whole window, guaranteeing overflow on the first token of
+   any prompt. A default like `min(4096, contextWindow // 4)` would be safer.
+2. litellm classifying a context-length error as `provider_error/transient` causes a
+   12× retry storm + deployment cooldown on what is a permanent 400 — worth a
+   non-retryable mapping.

--- a/eval/_tooling/scripts/gen_tasks.py
+++ b/eval/_tooling/scripts/gen_tasks.py
@@ -32,9 +32,13 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent       # eval/_tooling/scripts
 EVAL_ROOT = HERE.parents[1]                   # eval/  (benchmarks live directly under it)
 
-SIMPLEQA_CSV = (
+# SimpleQA source. An optional local copy of the CSV in the benchmark dir
+# (gitignored) lets gen read it offline; when absent, gen downloads the upstream
+# snapshot at the URL below.
+SIMPLEQA_CSV_URL = (
     "https://openaipublic.blob.core.windows.net/simple-evals/simple_qa_test_set.csv"
 )
+SIMPLEQA_CSV_LOCAL = EVAL_ROOT / "benchmarks" / "simpleqa" / "simple_qa_test_set.csv"
 
 # ---------------------------------------------------------------------------
 # Static task assets (identical across every task of a benchmark).
@@ -235,8 +239,11 @@ def _write_task(task_dir: Path, *, benchmark: str, question: str, answer: str, n
 
 
 def gen_simpleqa(n: int) -> list[tuple[str, str]]:
-    with urllib.request.urlopen(SIMPLEQA_CSV) as resp:  # noqa: S310 (trusted URL)
-        text = resp.read().decode("utf-8")
+    if SIMPLEQA_CSV_LOCAL.exists():
+        text = SIMPLEQA_CSV_LOCAL.read_text(encoding="utf-8")
+    else:  # vendored copy missing — fetch the upstream snapshot
+        with urllib.request.urlopen(SIMPLEQA_CSV_URL) as resp:  # noqa: S310 (trusted URL)
+            text = resp.read().decode("utf-8")
     rows = list(csv.DictReader(io.StringIO(text)))
     out = []
     for row in rows[:n]:

--- a/eval/benchmarks/simpleqa/.gitignore
+++ b/eval/benchmarks/simpleqa/.gitignore
@@ -1,1 +1,2 @@
 /tasks/
+/simple_qa_test_set.csv


### PR DESCRIPTION
## What

The full agentic BenchFlow run against a self-hosted engine (SGLang/vLLM) was 500'ing on every call. Root cause: benchflow's pi-acp defaulted the model's `maxTokens` to `16384` (the entire context), so `prompt + completion` overflowed and SGLang rejected every request — which litellm mislabeled as a *transient* HTTP 500.

## Changes

- **`_tooling/Makefile`** — inject `BENCHFLOW_PROVIDER_MODELS` with a `maxTokens` cap (`ENGINE_MAXTOK=2048`) for `vllm/` self-hosted models so the completion fits the 16384 context.
- **`docs/benchflow-engine-500.md`, `README.md`** — rewrite from "open / streaming red herring" to **resolved**, with the real root cause, the proxy `stderr.log` proof, the fix, and upstream-worthy notes for benchflow-ai.
- **`scripts/gen_tasks.py`** — read an optional local SimpleQA CSV if present, otherwise fetch the upstream snapshot (no longer assumes a committed copy).
- **`benchmarks/simpleqa/.gitignore`** — ignore `simple_qa_test_set.csv` (a regenerable download, not vendored). The local copy was removed.

## Verification

A 2-task `make eval` run went from `errored=2` (all HTTP 500) to `errored=0, n_tool_calls=1` with real answers — the maxTokens cap is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)